### PR TITLE
Resolved issues #49 and #52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,12 @@ push_sp_mock_frontend_image:
 
 push_sp_mock_backend_image:
 	aws lightsail push-container-image --region ca-central-1 --service-name container-service-3 --label backenda6 --image sp_mock_backend:latest
+
+run_local_db:
+	docker run -d --rm \
+		--name layer8-resource \
+		-v $(PWD)/.docker/postgres:/var/lib/postgresql/data \
+		-e POSTGRES_USER=postgres \
+		-e POSTGRES_PASSWORD=postgres \
+		-e POSTGRES_DBNAME=postgres \
+		-p 5434:5432 postgres:14.3

--- a/interceptor/Makefile
+++ b/interceptor/Makefile
@@ -7,7 +7,7 @@ ARG :=
 
 # ALTERED PATH
 define base64_encode
-	mkdir -p ../proxy/assets/cdn/interceptor/`dirname $(1) | cut -d'/' -f3` && \
+	mkdir -p ../server/assets-v1/assets/cdn/interceptor/`dirname $(1) | cut -d'/' -f3` && \
 	base64 -w 0 $(1) | sed 's/^/"/' | sed 's/$$/"/' > ../server/assets-v1/cdn/interceptor/`basename $(1) | cut -d'.' -f1`.json && \
 	echo "Encoded $(1) to ../server/assets-v1/cdn/interceptor/`basename $(1) | cut -d'.' -f1`.json";
 endef
@@ -37,4 +37,4 @@ encode: ## Encode the file specified by ARG or all files in ./bin if no ARG is s
 	fi
 
 build_local_cheating: ## Build the WASM interceptor without binary conversion
-	@GOOS=js GOARCH=wasm go build -ldflags="-X main.Layer8Scheme=$(LAYER8_PROXY_SCHEME_LOCAL) -X main.Layer8Host=$(LAYER8_PROXY_DOMAIN_LOCAL) -X main.Layer8Port=$(LAYER8_PROXY_PORT_LOCAL)" -o ../proxy/assets/cdn/interceptor/interceptor__local.wasm ./interceptor.go
+	@GOOS=js GOARCH=wasm go build -ldflags="-X main.Layer8Scheme=$(LAYER8_PROXY_SCHEME_LOCAL) -X main.Layer8Host=$(LAYER8_PROXY_DOMAIN_LOCAL) -X main.Layer8Port=$(LAYER8_PROXY_PORT_LOCAL)" -o ../server/assets-v1/cdn/interceptor/interceptor__local.wasm ./interceptor.go

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"globe-and-citizen/layer8/interceptor/internals"
@@ -167,16 +166,9 @@ func initializeECDHTunnel(this js.Value, args []js.Value) interface{} {
 
 		Respbody := utils.ReadResponseBody(resp.Body)
 
-		respBodyConverted, err := base64.URLEncoding.DecodeString(string(Respbody))
-		if err != nil {
-			fmt.Println(err.Error())
-			ETunnelFlag = false
-			return
-		}
-
 		data := map[string]interface{}{}
 
-		err = json.Unmarshal(respBodyConverted, &data)
+		err = json.Unmarshal(Respbody, &data)
 		if err != nil {
 			if strings.Contains(err.Error(), "unexpected end of JSON input") {
 				fmt.Println("JSON data might be incomplete or improperly formatted.")

--- a/interceptor/internals/main.go
+++ b/interceptor/internals/main.go
@@ -74,7 +74,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -88,7 +88,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -99,7 +99,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -112,7 +112,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -131,7 +131,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -152,7 +152,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: "mapB[\"data\"].(string) not 'ok'",
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -163,7 +163,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -176,7 +176,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
-			Headers: make(map[string]string),
+			Headers:    make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte

--- a/interceptor/internals/main.go
+++ b/interceptor/internals/main.go
@@ -43,7 +43,7 @@ func (c *Client) transfer(sharedSecret *utils.JWK, req *utils.Request, url strin
 	// encode request body
 	b, err := req.ToJSON()
 	if err != nil {
-		return nil, fmt.Errorf("Could not encode request: %w", err)
+		return nil, fmt.Errorf("could not encode request: %w", err)
 	}
 	// send the request
 	_, res := c.do(b, sharedSecret, url, req.Headers)
@@ -74,6 +74,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -87,6 +88,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -97,6 +99,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -109,6 +112,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -127,6 +131,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -147,6 +152,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: "mapB[\"data\"].(string) not 'ok'",
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -157,6 +163,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte
@@ -169,6 +176,7 @@ func (c *Client) do(data []byte, sharedSecret *utils.JWK, backendUrl string, hea
 		res := &utils.Response{
 			Status:     500,
 			StatusText: err.Error(),
+			Headers: make(map[string]string),
 		}
 		resByte, _ := res.ToJSON()
 		return 500, resByte

--- a/server/handlers/tunnel.go
+++ b/server/handlers/tunnel.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -104,7 +103,7 @@ func InitTunnel(w http.ResponseWriter, r *http.Request) {
 	upJWT, err := utilities.GenerateStandardToken(os.Getenv("UP_999_SECRET_KEY"))
 	if err != nil {
 		fmt.Println(err.Error())
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -116,7 +115,7 @@ func InitTunnel(w http.ResponseWriter, r *http.Request) {
 	server_pubKeyECDH, err := utilities.B64ToJWK(string(resBodyTempBytes))
 	if err != nil {
 		fmt.Println(err.Error())
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -137,8 +136,6 @@ func InitTunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dataToSendB64 := base64.URLEncoding.EncodeToString(datatoSend)
-
 	// io.Copy(w, bytes.NewBufferString(dataToSendB64))
 
 	// io.Copy(w, strings.NewReader(dataToSendB64))
@@ -146,7 +143,7 @@ func InitTunnel(w http.ResponseWriter, r *http.Request) {
 	// io.Copy(w, dataIoReader)
 
 	// io.CopyBuffer(w, bytes.NewBufferString(dataToSendB64), []byte(dataToSendB64))
-	w.Write([]byte(dataToSendB64))
+	w.Write(datatoSend)
 
 }
 


### PR DESCRIPTION
This PR:
- fixes #49: This issue originates from https://github.com/globe-and-citizen/layer8/blob/6df9a16e979b6400ec62ef4357167f079779cf1b/interceptor/internals/main.go#L57-L59 and is caused by not initializing the `Headers` (a map defined as `map[string]string`) field of the `utils.Response` struct, hence the `assignment to entry in nil map` error. So when the `Client.do` method gets an error from the external calls and returns to the `Client.transfer` method without initializing the `Headers`, it panics as it is in a zero state (`nil`)
- fixes #52 

Other fixes:
- Noticed that the proxy's `Tunnel` handler returns a `401 unauthorized` status for some internal errors, making debugging quite difficult. These were changed to return code `500`
- Also in the `Tunnel` handler, the base64 response data fails to decode in the interceptor (at times). Since `json.Marshal` returns encoded data in `[]byte` type, I thought it might not be necessary to explicitly encode again. This was modified, and the interceptor can simply read the JSON data directly from the buffer without having to explicitly decode again