### PR TITLE
fix: use custom delimeter for golang html template parser

### DIFF
--- a/server/assets-v1/templates/authorize.html
+++ b/server/assets-v1/templates/authorize.html
@@ -13,7 +13,7 @@
         };
         const logout = () => {
             document.cookie = 'token=; Max-Age=0'
-            var next = "{{ .Next }}"
+            var next = "[[ .Next ]]"
             window.location.href = '/login' + (next ? '?next=' + next : '')
         };
     </script>

--- a/server/assets-v1/templates/homeView.html
+++ b/server/assets-v1/templates/homeView.html
@@ -135,7 +135,7 @@
             return;
           }
 
-          await window.fetch("{{ .ProxyURL }}/api/v1/register-user", {
+          await window.fetch("[[ .ProxyURL ]]/api/v1/register-user", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -165,7 +165,7 @@
             return;
           }
 
-          const respOne = await window.fetch("{{ .ProxyURL }}/api/v1/login-precheck",
+          const respOne = await window.fetch("[[ .ProxyURL ]]/api/v1/login-precheck",
             {
               method: "POST",
               headers: {
@@ -178,7 +178,7 @@
           );
           const responseOne = await respOne.json();
 
-          const respTwo = await window.fetch("{{ .ProxyURL }}/api/v1/login-user",
+          const respTwo = await window.fetch("[[ .ProxyURL ]]/api/v1/login-user",
             {
               method: "POST",
               headers: {

--- a/server/assets-v1/templates/login.html
+++ b/server/assets-v1/templates/login.html
@@ -17,7 +17,7 @@
             <h2 class="center">Login</h2>
             <br>
             <form action="/login[[if .HasNext]]?next=[[.Next]][[end]]" method="POST">
-                <input type="hidden" name="next" value="{{.Next}}">
+                <input type="hidden" name="next" value="[[.Next]]">
                 <input aria-required="true" type="text" name="username" id="username" placeholder="Username" required>
                 <input aria-required="true" type="password" name="password" id="password" placeholder="Password" required>
                 <input aria-required="true" type="submit" value="Login">

--- a/server/assets-v1/templates/login.html
+++ b/server/assets-v1/templates/login.html
@@ -16,14 +16,14 @@
         <div class="body">
             <h2 class="center">Login</h2>
             <br>
-            <form action="/login{{if .HasNext}}?next={{.Next}}{{end}}" method="POST">
+            <form action="/login[[if .HasNext]]?next=[[.Next]][[end]]" method="POST">
                 <input type="hidden" name="next" value="{{.Next}}">
                 <input aria-required="true" type="text" name="username" id="username" placeholder="Username" required>
                 <input aria-required="true" type="password" name="password" id="password" placeholder="Password" required>
                 <input aria-required="true" type="submit" value="Login">
-                <small class="error">{{if .Error}}{{.Error}}{{end}}</small>
+                <small class="error">[[if .Error]][[.Error]][[end]]</small>
             </form>
-                <a href="{{ .ProxyURL }}/register">Don't have an account? Register</a>
+                <a href="[[ .ProxyURL ]]/register">Don't have an account? Register</a>
             <br>
         </div>
     </div>

--- a/server/assets-v1/templates/registerClient.html
+++ b/server/assets-v1/templates/registerClient.html
@@ -126,7 +126,7 @@
             alert("Please enter a name and redirect url!");
             return;
           }
-          await window.fetch("{{ .ProxyURL }}/api/v1/register-client", {
+          await window.fetch("[[ .ProxyURL ]]/api/v1/register-client", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -146,7 +146,7 @@
       };
       const getClientData = async (clientName) => {
         try {
-          const resp = await window.fetch("{{ .ProxyURL }}/api/v1/getClient", {
+          const resp = await window.fetch("[[ .ProxyURL ]]/api/v1/getClient", {
               method: "GET",
               headers: {
                 "Content-Type": "Application/Json",

--- a/server/assets-v1/templates/userView.html
+++ b/server/assets-v1/templates/userView.html
@@ -65,7 +65,7 @@
       const getUserDetails = async () => {
         try {
           //const resp = await window.fetch("https://layer8devproxy.net/api/v1/profile",
-          const resp = await window.fetch("{{ .ProxyURL }}/api/v1/profile",
+          const resp = await window.fetch("[[ .ProxyURL ]]/api/v1/profile",
             {
               method: "GET",
               headers: {
@@ -86,12 +86,12 @@
         token.value = null;
         localStorage.removeItem("token");
         /* router.push("/"); */
-        window.location.href = "{{ .ProxyURL }}/";
+        window.location.href = "[[ .ProxyURL ]]/";
       };
 
       const verifyEmail = async () => {
         try {
-          const resp = await window.fetch("{{ .ProxyURL }}/api/v1/verify-email", {
+          const resp = await window.fetch("[[ .ProxyURL ]]/api/v1/verify-email", {
               method: "POST",
               headers: {
                 "Content-Type": "Application/Json",
@@ -118,7 +118,7 @@
             alert("Please enter a display name!");
             return;
           }
-          const resp = await window.fetch("{{ .ProxyURL }}/api/v1/change-display-name",
+          const resp = await window.fetch("[[ .ProxyURL ]]/api/v1/change-display-name",
             {
               method: "POST",
               headers: {

--- a/server/handlers/authentication.go
+++ b/server/handlers/authentication.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	svc "globe-and-citizen/layer8/server/internals/service"
+	"globe-and-citizen/layer8/server/resource_server/utils"
 	"html/template"
 	"net/http"
 	"os"
@@ -26,17 +27,13 @@ func Login(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// load the login page
-		t, err := template.ParseFiles("assets-v1/templates/login.html")
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		t.Execute(w, map[string]interface{}{
-			"HasNext":  next != "",
-			"Next":     next,
-			"ProxyURL": os.Getenv("PROXY_URL"),
-		})
+		utils.ParseHTML(w, "login.html",
+			map[string]interface{}{
+				"HasNext":  next != "",
+				"Next":     next,
+				"ProxyURL": os.Getenv("PROXY_URL"),
+			},
+		)
 		return
 	case "POST":
 		next := r.URL.Query().Get("next")
@@ -105,17 +102,13 @@ func Register(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// load the login page
-		t, err := template.ParseFiles("assets-v1/templates/registerClient.html")
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		t.Execute(w, map[string]interface{}{
-			"HasNext":  next != "",
-			"Next":     next,
-			"ProxyURL": os.Getenv("PROXY_URL"),
-		})
+		utils.ParseHTML(w, "registerClient.html",
+			map[string]interface{}{
+				"HasNext":  next != "",
+				"Next":     next,
+				"ProxyURL": os.Getenv("PROXY_URL"),
+			},
+		)
 		return
 	case "POST":
 		next := r.URL.Query().Get("next")
@@ -124,35 +117,31 @@ func Register(w http.ResponseWriter, r *http.Request) {
 		// login the user
 		rUser, err := service.LoginUser(username, password)
 		if err != nil {
-			t, errT := template.ParseFiles("assets-v1/templates/registerClient.html")
-			if errT != nil {
-				http.Error(w, errT.Error(), http.StatusInternalServerError)
-				return
-			}
-			t.Execute(w, map[string]interface{}{
-				"HasNext":  next != "",
-				"Next":     next,
-				"Error":    err.Error(),
-				"ProxyURL": os.Getenv("PROXY_URL"),
-			})
+			utils.ParseHTML(w, "registerClient.html",
+				map[string]interface{}{
+					"HasNext":  next != "",
+					"Next":     next,
+					"Error":    err.Error(),
+					"ProxyURL": os.Getenv("PROXY_URL"),
+				},
+			)
 			return
 		}
+
 		// set the token cookie
 		token, ok := rUser["token"].(string)
 		if !ok {
-			t, err := template.ParseFiles("assets-v1/templates/registerClient.html")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			t.Execute(w, map[string]interface{}{
-				"HasNext":  next != "",
-				"Next":     next,
-				"Error":    "could not get token",
-				"ProxyURL": os.Getenv("PROXY_URL"),
-			})
+			utils.ParseHTML(w, "registerClient.html",
+				map[string]interface{}{
+					"HasNext":  next != "",
+					"Next":     next,
+					"Error":    "could not get token",
+					"ProxyURL": os.Getenv("PROXY_URL"),
+				},
+			)
 			return
 		}
+
 		http.SetCookie(w, &http.Cookie{
 			Name:  "token",
 			Value: token,

--- a/server/handlers/authentication.go
+++ b/server/handlers/authentication.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	svc "globe-and-citizen/layer8/server/internals/service"
 	"globe-and-citizen/layer8/server/resource_server/utils"
-	"html/template"
 	"net/http"
 	"os"
 )
@@ -42,31 +41,25 @@ func Login(w http.ResponseWriter, r *http.Request) {
 		// login the user
 		rUser, err := service.LoginUser(username, password)
 		if err != nil {
-			t, errT := template.ParseFiles("assets-v1/templates/login.html")
-			if errT != nil {
-				http.Error(w, errT.Error(), http.StatusInternalServerError)
-				return
-			}
-			t.Execute(w, map[string]interface{}{
-				"HasNext": next != "",
-				"Next":    next,
-				"Error":   err.Error(),
-			})
+			utils.ParseHTML(w, "login.html",
+				map[string]interface{}{
+					"HasNext": next != "",
+					"Next":    next,
+					"Error":   err.Error(),
+				},
+			)
 			return
 		}
 		// set the token cookie
 		token, ok := rUser["token"].(string)
 		if !ok {
-			t, err := template.ParseFiles("assets-v1/templates/login.html")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			t.Execute(w, map[string]interface{}{
-				"HasNext": next != "",
-				"Next":    next,
-				"Error":   "could not get token",
-			})
+			utils.ParseHTML(w, "login.html",
+				map[string]interface{}{
+					"HasNext": next != "",
+					"Next":    next,
+					"Error":   "could not get token",
+				},
+			)
 			return
 		}
 		http.SetCookie(w, &http.Cookie{

--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -2,11 +2,8 @@ package controller
 
 import (
 	"encoding/json"
-	"fmt"
-	"html/template"
 	"net/http"
 	"os"
-	"path/filepath"
 
 	"globe-and-citizen/layer8/server/resource_server/dto"
 	"globe-and-citizen/layer8/server/resource_server/interfaces"
@@ -14,73 +11,33 @@ import (
 )
 
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
-
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		fmt.Fprintln(w, http.StatusText(http.StatusMethodNotAllowed))
+	if !utils.IsMethodValid(w, r, http.MethodGet) {
 		return
 	}
 
-	utils.GetPwd()
-
-	// var relativePathIndex = "assets-v1/templates/homeView.html"
-	// indexPath := filepath.Join(utils.WorkingDirectory, relativePathIndex)
-	// fmt.Println("indexPath: ", indexPath)
-	// http.ServeFile(w, r, indexPath)
-
-	// load the homeView page
-	t, err := template.ParseFiles("assets-v1/templates/homeView.html")
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	t.Execute(w, map[string]interface{}{
+	utils.ParseHTML(w, "homeView.html", map[string]interface{}{
 		"ProxyURL": os.Getenv("PROXY_URL"),
 	})
-
 }
 
 func UserHandler(w http.ResponseWriter, r *http.Request) {
-
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		fmt.Fprintln(w, http.StatusText(http.StatusMethodNotAllowed))
+	if !utils.IsMethodValid(w, r, http.MethodGet) {
 		return
 	}
 
-	utils.GetPwd()
-
-	var relativePathUser = "assets-v1/templates/userView.html"
-	userPath := filepath.Join(utils.WorkingDirectory, relativePathUser)
-	fmt.Println("userPath: ", userPath)
-	http.ServeFile(w, r, userPath)
+	utils.ParseHTML(w, "userView.html", map[string]interface{}{
+		"ProxyURL": os.Getenv("PROXY_URL"),
+	})
 }
 
 func ClientHandler(w http.ResponseWriter, r *http.Request) {
-
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		fmt.Fprintln(w, http.StatusText(http.StatusMethodNotAllowed))
+	if !utils.IsMethodValid(w, r, http.MethodGet) {
 		return
 	}
 
-	utils.GetPwd()
-
-	var relativePathUser = "assets-v1/templates/registerClient.html"
-	userPath := filepath.Join(utils.WorkingDirectory, relativePathUser)
-	fmt.Println("userPath: ", userPath)
-	http.ServeFile(w, r, userPath)
-
-	// load the registerClient page
-	// t, err := template.ParseFiles("assets-v1/templates/registerClient.html")
-	// if err != nil {
-	// 	http.Error(w, err.Error(), http.StatusInternalServerError)
-	// 	return
-	// }
-
-	// t.Execute(w, map[string]interface{}{
-	// 	"ProxyURL": os.Getenv("PROXY_URL"),
-	// })
+	utils.ParseHTML(w, "registerClient.html", map[string]interface{}{
+		"ProxyURL": os.Getenv("PROXY_URL"),
+	})
 }
 
 func RegisterUserHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/resource_server/utils/html.go
+++ b/server/resource_server/utils/html.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"text/template"
+)
+
+func ParseHTML(
+	w http.ResponseWriter,
+	htmlFile string,
+	params map[string]interface{},
+) {
+	t, err := template.New(htmlFile).Delims("[[", "]]").ParseFiles(fmt.Sprintf("assets-v1/templates/%s", htmlFile))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := t.Execute(w, params); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/server/resource_server/utils/http.go
+++ b/server/resource_server/utils/http.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func IsMethodValid(w http.ResponseWriter, r *http.Request, method string) bool {
+	if r.Method != method {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprintln(w, http.StatusText(http.StatusMethodNotAllowed))
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
This merge request addresses a delimiter clash issue between Go's template parser and Vue.js. 

Previously, both Go and Vue.js were using "{{ }}" as delimiters, which led to conflicts when trying to render templates. 

With this change, the Go template parser will now use "[[ ]]" as delimiters, effectively resolving the conflict with Vue.js.

This change affects all areas where the Go template parser is used, so thorough testing is recommended to ensure that all templates render as expected.