### PR TITLE
fix: handle conflicting route

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -137,7 +137,7 @@ func Server(port int, service interfaces.IService, memoryRepository interfaces.I
 			staticFS, _ := fs.Sub(StaticFiles, "dist")
 			httpFS := http.FileServer(http.FS(staticFS))
 
-			if r.Header.Get("X-Forwarded-Proto") != "" {
+			if r.Header.Get("up-JWT") != "" {
 				handlers.Tunnel(w, r)
 				return
 			}


### PR DESCRIPTION
This PR fix issue #23, previously we fixed it (https://github.com/globe-and-citizen/layer8/pull/25) by checking if X-FORWARDED-HOST exists then forward to tunnel api but unfortunately the header is used in cloudflare hence all request forwarded to tunnel api.