### PR TITLE
devops: deployment pipeline

### DIFF
--- a/.github/workflows/dev-influxdb.yml
+++ b/.github/workflows/dev-influxdb.yml
@@ -1,0 +1,39 @@
+
+name: Deploy InfluxDB to Development Environment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-influxdb:
+    runs-on: ubuntu-latest
+    environment: "development"
+    defaults:
+      run:
+        working-directory: ./infra/development/influxdb
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Add Terraform Environment Variables
+        id: addtfenv
+        run: |
+          echo -e "$TFVARS_STRING" >> terraform.tfvars
+        env:
+          TFVARS_STRING: |
+            cloudflare_tunnel_token = "${{ secrets.DEVELOPMENT_INFLUXDB_CLOUDFLARE_TUNNEL_TOKEN }}"
+      
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply

--- a/.github/workflows/dev-network.yml
+++ b/.github/workflows/dev-network.yml
@@ -1,4 +1,4 @@
-name: Deploy Network to Production Environment
+name: Deploy Network to Development Environment
 
 on:
   workflow_dispatch:
@@ -9,12 +9,23 @@ jobs:
       environment: "production"
       defaults:
         run:
-          working-directory: ./infra/production/base
+          working-directory: ./infra/development/base
       steps:
         - uses: actions/checkout@v4
         - uses: hashicorp/setup-terraform@v3
           with:
             cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}  
+            
+        - name: Add Terraform Environment Variables
+          id: addtfenv
+          run: |
+            echo -e "$TFVARS_STRING" >> terraform.tfvars
+          env:
+            TFVARS_STRING: |
+              iam_profile_arn = "${{ vars.IAM_PROFILE_ARN }}"
+              task_role_arn = "${{ secrets.ECS_TASK_ROLE_ARN }}"
+              task_execution_role_arn = "${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}"
+
         - name: Terraform Init
           id: init
           run: terraform init

--- a/.github/workflows/dev-network.yml
+++ b/.github/workflows/dev-network.yml
@@ -1,0 +1,32 @@
+name: Deploy Network to Production Environment
+
+on:
+  workflow_dispatch:
+
+jobs:
+    deploy-network:
+      runs-on: ubuntu-latest
+      environment: "production"
+      defaults:
+        run:
+          working-directory: ./infra/production/base
+      steps:
+        - uses: actions/checkout@v4
+        - uses: hashicorp/setup-terraform@v3
+          with:
+            cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}  
+        - name: Terraform Init
+          id: init
+          run: terraform init
+
+        - name: Terraform Validate
+          id: validate
+          run: terraform validate
+
+        - name: Terraform Plan
+          id: plan
+          run: terraform plan
+
+        - name: Terraform Apply
+          id: apply
+          run: terraform apply

--- a/.github/workflows/dev-service.yml
+++ b/.github/workflows/dev-service.yml
@@ -63,6 +63,7 @@ jobs:
             influxdb_token = "${{ secrets.DEVELOPMENT_INFLUXDB_TOKEN }}"
             task_role_arn = "${{ secrets.ECS_TASK_ROLE_ARN }}"
             task_execution_role_arn = "${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}"
+            cloudflare_tunnel_token = "${{ secrets.DEVELOPMENT_LAYER8_CLOUDFLARE_TUNNEL_TOKEN }}"
       
       - name: Terraform Init
         id: init

--- a/.github/workflows/dev-service.yml
+++ b/.github/workflows/dev-service.yml
@@ -1,0 +1,77 @@
+name: Deploy Layer8 Server to Development Environment
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - development
+
+jobs:
+  build-layer8:
+    name: Build Layer8 Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kciter/aws-ecr-action@v3
+        with:
+          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          repo: layer8
+          region: ${{ vars.AWS_REGION }}
+          tags: latest,${{ github.sha }}
+          create_repo: true
+  deploy-layer8-server-development:
+    name: "Deploy Layer 8 to Development"
+    environment: "development"
+    needs: [build-layer8]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/development/layer8
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli
+      - name: Populate Application Environment Variables to S3
+        id: populateappenv
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+        run: |
+          echo -e "${{ vars.DEVELOPMENT_APP_ENV }}" >> app.env
+          aws s3 cp ./app.env s3://${{ vars.DEVELOPMENT_S3_APP_ENV_LOCATION }}
+      
+      - name: Add Terraform Environment Variables
+        id: addtfenv
+        run: |
+          echo -e "$TFVARS_STRING" >> terraform.tfvars
+        env:
+          TFVARS_STRING: |
+            ecr_image_tag = "${{ github.sha }}"
+            s3_arn_env_file = "arn:aws:s3:::${{ vars.DEVELOPMENT_S3_APP_ENV_LOCATION }}"
+            ecr_repository_url = "${{ vars.ECR_REPOSITORY_URL }}"
+            influxdb_url = "${{ vars.DEVELOPMENT_INFLUXDB_URL }}"
+            influxdb_token = "${{ secrets.DEVELOPMENT_INFLUXDB_TOKEN }}"
+            task_role_arn = "${{ secrets.ECS_TASK_ROLE_ARN }}"
+            task_execution_role_arn = "${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}"
+      
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply

--- a/.github/workflows/prod-influxdb.yml
+++ b/.github/workflows/prod-influxdb.yml
@@ -1,0 +1,39 @@
+
+name: Deploy InfluxDB to Production Environment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-influxdb:
+    runs-on: ubuntu-latest
+    environment: "production"
+    defaults:
+      run:
+        working-directory: ./infra/production/influxdb
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Add Terraform Environment Variables
+        id: addtfenv
+        run: |
+          echo -e "$TFVARS_STRING" >> terraform.tfvars
+        env:
+          TFVARS_STRING: |
+            cloudflare_tunnel_token = "${{ secrets.PRODUCTION_INFLUXDB_CLOUDFLARE_TUNNEL_TOKEN }}"
+      
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply

--- a/.github/workflows/prod-network.yml
+++ b/.github/workflows/prod-network.yml
@@ -1,0 +1,32 @@
+name: Deploy Network to Production Environment
+
+on:
+  workflow_dispatch:
+
+jobs:
+    deploy-network:
+      runs-on: ubuntu-latest
+      environment: "production"
+      defaults:
+        run:
+          working-directory: ./infra/production/base
+      steps:
+        - uses: actions/checkout@v4
+        - uses: hashicorp/setup-terraform@v3
+          with:
+            cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}  
+        - name: Terraform Init
+          id: init
+          run: terraform init
+
+        - name: Terraform Validate
+          id: validate
+          run: terraform validate
+
+        - name: Terraform Plan
+          id: plan
+          run: terraform plan
+
+        - name: Terraform Apply
+          id: apply
+          run: terraform apply

--- a/.github/workflows/prod-service.yml
+++ b/.github/workflows/prod-service.yml
@@ -1,0 +1,75 @@
+name: Deploy Layer8 Server to Production Environment
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - production
+
+jobs:
+  build-layer8:
+    name: Build Layer8 Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kciter/aws-ecr-action@v3
+        with:
+          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          repo: layer8
+          region: ${{ vars.AWS_REGION }}
+          tags: latest,${{ github.sha }}
+          create_repo: true
+  deploy-layer8-server-production:
+    name: "Deploy Layer 8 to Production"
+    environment: "production"
+    needs: [build-layer8]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/production/layer8
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli
+      - name: Populate Application Environment Variables to S3
+        id: populateappenv
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+        run: |
+          echo -e "${{ vars.PRODUCTION_APP_ENV }}" >> app.env
+          aws s3 cp ./app.env s3://${{ vars.PRODUCTION_S3_APP_ENV_LOCATION }}
+      
+      - name: Add Terraform Environment Variables
+        id: addtfenv
+        run: |
+          echo -e "$TFVARS_STRING" >> terraform.tfvars
+        env:
+          TFVARS_STRING: |
+            ecr_image_tag = "${{ github.sha }}"
+            s3_arn_env_file = "arn:aws:s3:::${{ vars.PRODUCTION_S3_APP_ENV_LOCATION }}"
+            ecr_repository_url = "${{ vars.ECR_REPOSITORY_URL }}"
+            influxdb_url = "${{ vars.PRODUCTION_INFLUXDB_URL }}"
+            influxdb_token = "${{ secrets.PRODUCTION_INFLUXDB_TOKEN }}"
+      
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply

--- a/.github/workflows/prod-service.yml
+++ b/.github/workflows/prod-service.yml
@@ -61,6 +61,7 @@ jobs:
             ecr_repository_url = "${{ vars.ECR_REPOSITORY_URL }}"
             influxdb_url = "${{ vars.PRODUCTION_INFLUXDB_URL }}"
             influxdb_token = "${{ secrets.PRODUCTION_INFLUXDB_TOKEN }}"
+            cloudflare_tunnel_token = "${{ secrets.PRODUCTION_LAYER8_CLOUDFLARE_TUNNEL_TOKEN }}"
       
       - name: Terraform Init
         id: init

--- a/.github/workflows/prod-service.yml
+++ b/.github/workflows/prod-service.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - production
+      - main
 
 jobs:
   build-layer8:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go get github.com/globe-and-citizen/layer8-utils
 
 RUN go mod tidy
 
-RUN go build -o main .
+RUN GOOS=linux GOARCH=amd64 go build -o main .
 
 # Deploy the server
 
@@ -23,11 +23,11 @@ WORKDIR /layer8-app
 
 COPY --from=builder /build/main /layer8-app
 
-COPY --from=builder /build/.env /layer8-app
-
 COPY --from=builder /build/assets-v1 /layer8-app/assets-v1
 
 COPY --from=builder /build/certificates /layer8-app/certificates
+
+RUN touch /layer8-app/.env
 
 EXPOSE 5001
 

--- a/infra/development/base/main.tf
+++ b/infra/development/base/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  backend "remote" {
+    organization = "globe-and-citizen"
+    workspaces {
+      name = "network-development"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.AWS_REGION
+}
+
+module "network" {
+  source = "./module/network"
+}
+
+module "iam" {
+  source = "./module/iam"
+}
+
+module "ecs" {
+  source                  = "./module/ecs"
+  cluster_name            = "layer8-development"
+  vpc_cidr_block          = module.network.vpc_cidr_block
+  vpc_id                  = module.network.vpc_id
+  subnets                 = module.network.private_subnets
+  iam_profile_arn         = var.iam_profile_arn
+  task_execution_role_arn = var.task_execution_role_arn
+  task_role_arn           = var.task_role_arn
+  aws_region              = var.AWS_REGION
+}
+
+module "ecr" {
+  source = "./module/ecr"
+}
+
+module "s3" {
+  source = "./module/s3"
+}

--- a/infra/development/base/main.tf
+++ b/infra/development/base/main.tf
@@ -15,10 +15,6 @@ module "network" {
   source = "./module/network"
 }
 
-module "iam" {
-  source = "./module/iam"
-}
-
 module "ecs" {
   source                  = "./module/ecs"
   cluster_name            = "layer8-development"
@@ -29,12 +25,4 @@ module "ecs" {
   task_execution_role_arn = var.task_execution_role_arn
   task_role_arn           = var.task_role_arn
   aws_region              = var.AWS_REGION
-}
-
-module "ecr" {
-  source = "./module/ecr"
-}
-
-module "s3" {
-  source = "./module/s3"
 }

--- a/infra/development/base/module/ecs/capacity_provider.tf
+++ b/infra/development/base/module/ecs/capacity_provider.tf
@@ -58,5 +58,11 @@ resource "aws_ecs_capacity_provider" "service_spot_capacity_provider" {
   auto_scaling_group_provider {
     auto_scaling_group_arn         = aws_autoscaling_group.service_spot_asg.arn
     managed_termination_protection = "DISABLED"
+    managed_scaling {
+      maximum_scaling_step_size = 2
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 100
+    }
   }
 }

--- a/infra/development/base/module/ecs/capacity_provider.tf
+++ b/infra/development/base/module/ecs/capacity_provider.tf
@@ -1,0 +1,62 @@
+resource "aws_launch_template" "service_spot_launch_template" {
+  name          = "${aws_ecs_cluster.cluster.name}-service-spot-launch-template"
+  image_id      = data.aws_ssm_parameter.ecs_node_ami.value
+  instance_type = "t3.micro"
+
+  iam_instance_profile { arn = var.iam_profile_arn }
+  monitoring { enabled = false }
+
+  user_data = base64encode(<<-EOF
+      #!/bin/bash
+      echo ECS_CLUSTER=${aws_ecs_cluster.cluster.name} >> /etc/ecs/ecs.config;
+    EOF
+  )
+}
+
+resource "aws_autoscaling_group" "service_spot_asg" {
+  name                = "${aws_ecs_cluster.cluster.name}-service-spot-asg"
+  min_size            = 1
+  max_size            = 1
+  capacity_rebalance  = "true"
+  vpc_zone_identifier = var.subnets[*].id
+
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_allocation_strategy            = "prioritized"
+      on_demand_base_capacity                  = "0"
+      on_demand_percentage_above_base_capacity = "0"
+      spot_allocation_strategy                 = "price-capacity-optimized"
+      spot_instance_pools                      = "0"
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.service_spot_launch_template.id
+        version            = "$Latest"
+      }
+
+      override {
+        instance_type = "t3.micro"
+      }
+
+      override {
+        instance_type = "t3a.micro"
+      }
+    }
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = ""
+    propagate_at_launch = true
+  }
+}
+
+
+resource "aws_ecs_capacity_provider" "service_spot_capacity_provider" {
+  name = "${aws_ecs_cluster.cluster.name}-service-spot-capacity-provider"
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.service_spot_asg.arn
+    managed_termination_protection = "DISABLED"
+  }
+}

--- a/infra/development/base/module/ecs/main.tf
+++ b/infra/development/base/module/ecs/main.tf
@@ -1,0 +1,44 @@
+resource "aws_ecs_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+data "aws_ssm_parameter" "ecs_node_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}
+
+resource "aws_ecs_cluster_capacity_providers" "capacity_provider_mapping" {
+  cluster_name = aws_ecs_cluster.cluster.name
+  capacity_providers = [
+    aws_ecs_capacity_provider.service_spot_capacity_provider.name
+  ]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.service_spot_capacity_provider.name
+    base              = 1
+    weight            = 100
+  }
+}
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name = "ecs/production"
+}
+
+resource "aws_security_group" "ecs_node_sg" {
+  name   = "ecs-node-sg-production"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr_block]
+    description = "vpc cidr"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/infra/development/base/module/ecs/main.tf
+++ b/infra/development/base/module/ecs/main.tf
@@ -20,11 +20,11 @@ resource "aws_ecs_cluster_capacity_providers" "capacity_provider_mapping" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name = "ecs/production"
+  name = "ecs/development"
 }
 
 resource "aws_security_group" "ecs_node_sg" {
-  name   = "ecs-node-sg-production"
+  name   = "ecs-node-sg-development"
   vpc_id = var.vpc_id
 
   ingress {

--- a/infra/development/base/module/ecs/outputs.tf
+++ b/infra/development/base/module/ecs/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_id" {
+  description = "ECS Cluster ID"
+  value       = aws_ecs_cluster.cluster.id
+}
+
+output "service_spot_capacity_provider_name" {
+  description = "ECS Capacity Provider Name for Service"
+  value       = aws_ecs_capacity_provider.service_spot_capacity_provider.name
+}
+
+output "security_group_id" {
+  description = "ECS Security Group ID"
+  value       = aws_security_group.ecs_node_sg.id
+}

--- a/infra/development/base/module/ecs/variables.tf
+++ b/infra/development/base/module/ecs/variables.tf
@@ -1,0 +1,25 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the ECS cluster"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block of the VPC for the ECS cluster"
+}
+
+variable "subnets" {
+  description = "List of the private subnets"
+}
+
+variable "iam_profile_arn" {
+  description = "IAM profile ARN for the ECS cluster"
+}
+
+variable "task_execution_role_arn" {}
+
+variable "task_role_arn" {}
+
+variable "aws_region" {}

--- a/infra/development/base/module/network/main.tf
+++ b/infra/development/base/module/network/main.tf
@@ -1,0 +1,93 @@
+data "aws_availability_zones" "available" { state = "available" }
+
+locals {
+  azs_count = 2
+  azs_names = data.aws_availability_zones.available.names
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "${terraform.workspace}-vpc"
+  }
+
+  enable_dns_hostnames = true
+}
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.vpc.id
+  count             = local.azs_count
+  cidr_block        = cidrsubnet(aws_vpc.vpc.cidr_block, 2, count.index)
+  availability_zone = local.azs_names[count.index]
+  tags = {
+    Name = "${terraform.workspace}-public-subnet"
+  }
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.vpc.id
+  count             = local.azs_count
+  cidr_block        = cidrsubnet(aws_vpc.vpc.cidr_block, 2, count.index + 2)
+  availability_zone = local.azs_names[count.index]
+  tags = {
+    Name = "${terraform.workspace}-private-subnet"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "${terraform.workspace}-gw"
+  }
+}
+
+resource "aws_eip" "nat" {
+  tags = {
+    Name = "${terraform.workspace}-nat-ip"
+  }
+}
+
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+
+  tags = {
+    Name = "${terraform.workspace}-public-route"
+  }
+}
+resource "aws_route_table_association" "public" {
+  count          = local.azs_count
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+module "fck-nat" {
+  source = "RaJiska/fck-nat/aws"
+
+  name               = "nat-instance"
+  vpc_id             = aws_vpc.vpc.id
+  subnet_id          = aws_subnet.public[0].id
+  eip_allocation_ids = [aws_eip.nat.allocation_id]
+
+  update_route_table = true
+  route_table_id     = aws_route_table.private.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${terraform.workspace}-private-route"
+  }
+}
+
+
+resource "aws_route_table_association" "private" {
+  count          = local.azs_count
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/development/base/module/network/main.tf
+++ b/infra/development/base/module/network/main.tf
@@ -68,7 +68,7 @@ resource "aws_route_table_association" "public" {
 module "fck-nat" {
   source = "RaJiska/fck-nat/aws"
 
-  name               = "nat-instance"
+  name               = "nat-instance-development"
   vpc_id             = aws_vpc.vpc.id
   subnet_id          = aws_subnet.public[0].id
   eip_allocation_ids = [aws_eip.nat.allocation_id]

--- a/infra/development/base/module/network/outputs.tf
+++ b/infra/development/base/module/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.vpc.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.vpc.cidr_block
+}
+
+output "public_subnets" {
+  description = "List of the public subnets"
+  value       = aws_subnet.public
+}
+
+output "private_subnets" {
+  description = "List of the private subnets"
+  value       = aws_subnet.private
+}

--- a/infra/development/base/outputs.tf
+++ b/infra/development/base/outputs.tf
@@ -1,0 +1,23 @@
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "ecs_cluster_id" {
+  value = module.ecs.cluster_id
+}
+
+output "service_spot_capacity_provider_name" {
+  value = module.ecs.service_spot_capacity_provider_name
+}
+
+output "private_subnets" {
+  value = module.network.private_subnets
+}
+
+output "node_security_group_id" {
+  value = module.ecs.security_group_id
+}
+
+output "ecr_repository_url" {
+  value = module.ecr.repository_url
+}

--- a/infra/development/base/outputs.tf
+++ b/infra/development/base/outputs.tf
@@ -17,7 +17,3 @@ output "private_subnets" {
 output "node_security_group_id" {
   value = module.ecs.security_group_id
 }
-
-output "ecr_repository_url" {
-  value = module.ecr.repository_url
-}

--- a/infra/development/base/variables.tf
+++ b/infra/development/base/variables.tf
@@ -1,0 +1,12 @@
+variable "AWS_REGION" {
+  description = "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc."
+  default     = "ap-southeast-2"
+}
+
+variable "iam_profile_arn" {
+  description = "IAM profile ARN for the ECS cluster"
+}
+
+variable "task_execution_role_arn" {}
+
+variable "task_role_arn" {}

--- a/infra/development/influxdb/main.tf
+++ b/infra/development/influxdb/main.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "ec2_instance" {
   instance_type = "t3.micro"
   key_name      = "key-pair-one"
 
-  subnet_id     = data.terraform_remote_state.network.outputs.private_subnets[0].id
+  subnet_id              = data.terraform_remote_state.network.outputs.private_subnets[0].id
   vpc_security_group_ids = [data.terraform_remote_state.network.outputs.node_security_group_id]
 
 
@@ -46,7 +46,7 @@ resource "aws_instance" "ec2_instance" {
       echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
       echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
       sudo apt-get update
-      sudo apt-get install influxdb2
+      sudo apt-get install -y influxdb2
       sudo systemctl start influxdb
       sudo systemctl enable influxdb
       

--- a/infra/development/influxdb/main.tf
+++ b/infra/development/influxdb/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  backend "remote" {
+    organization = "globe-and-citizen"
+    workspaces {
+      name = "layer8-influxdb-development"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "globe-and-citizen"
+    workspaces = {
+      name = "network-development"
+    }
+  }
+}
+
+resource "aws_instance" "ec2_instance" {
+  tags = {
+    Name = "influxdb2-development"
+  }
+
+  ami           = "ami-023adaba598e661ac"
+  instance_type = "t3.micro"
+  key_name      = "key-pair-one"
+
+  subnet_id     = data.terraform_remote_state.network.outputs.private_subnets[0].id
+  vpc_security_group_ids = [data.terraform_remote_state.network.outputs.node_security_group_id]
+
+
+  root_block_device {
+    volume_size = 10
+    volume_type = "gp3"
+  }
+
+  user_data = base64encode(<<-EOF
+      #!/bin/bash
+      wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+      echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+      echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
+      sudo apt-get update
+      sudo apt-get install influxdb2
+      sudo systemctl start influxdb
+      sudo systemctl enable influxdb
+      
+      sudo apt-get install cloudflared
+      curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb && 
+      sudo dpkg -i cloudflared.deb
+      sudo cloudflared service install ${var.cloudflare_tunnel_token}
+    EOF
+  )
+}

--- a/infra/development/influxdb/variables.tf
+++ b/infra/development/influxdb/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  default = "ap-southeast-2"
+}
+
+variable "cloudflare_tunnel_token" {}

--- a/infra/development/layer8/main.tf
+++ b/infra/development/layer8/main.tf
@@ -1,0 +1,179 @@
+terraform {
+  backend "remote" {
+    organization = "globe-and-citizen"
+    workspaces {
+      name = "layer8-server-development"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "globe-and-citizen"
+    workspaces = {
+      name = "network-development"
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "task_definition" {
+  family                   = "layer8-server"
+  task_role_arn            = var.task_role_arn
+  execution_role_arn       = var.task_execution_role_arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  skip_destroy             = true
+
+  container_definitions = jsonencode([
+    {
+      name              = "layer8-server",
+      essential         = true,
+      image             = "${var.ecr_repository_url}:${var.ecr_image_tag}",
+      cpu               = 0,
+      memoryReservation = 512,
+      mountPoints       = [],
+      portMappings = [
+        { containerPort = 5001, hostPort = 5001, protocol = "tcp" },
+      ],
+      environment = [],
+      environmentFiles = [
+        { type = "s3", value = var.s3_arn_env_file }
+      ],
+      systemControls = [],
+      volumesFrom    = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "ecs/development",
+          "awslogs-region" : "${var.aws_region}",
+          "awslogs-stream-prefix" : "layer8server"
+        },
+      },
+      user = "0"
+    },
+    {
+      name              = "cloudflared-tunnel",
+      essential         = true,
+      image             = "cloudflare/cloudflared:latest",
+      cpu               = 0,
+      memoryReservation = 128,
+      mountPoints       = [],
+      portMappings      = [],
+      environment       = [],
+      environmentFiles  = [],
+      systemControls    = [],
+      volumesFrom       = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "ecs/development",
+          "awslogs-region" : "${var.aws_region}",
+          "awslogs-stream-prefix" : "layer8tunnel"
+        },
+      },
+      user = "0",
+      command = [
+        "tunnel",
+        "--no-autoupdate",
+        "run",
+        "--token",
+        "${var.cloudflare_tunnel_token}"
+      ]
+    },
+    {
+      name              = "telegraf",
+      essential         = true,
+      image             = "hannmuhammadd/telegraf-opentelemetry-influxdb",
+      cpu               = 0,
+      memoryReservation = 128,
+      mountPoints       = [],
+      portMappings      = [],
+      environment = [
+        {
+          name  = "INFLUXDB_URL",
+          value = "${var.influxdb_url}",
+        },
+        {
+          name  = "INFLUXDB_TOKEN",
+          value = "${var.influxdb_token}",
+        },
+        {
+          name  = "INFLUXDB_ORGANIZATION",
+          value = "layer8",
+        },
+        {
+          name  = "INFLUXDB_BUCKET_NAME",
+          value = "layer8",
+        }
+      ],
+      environmentFiles = [],
+      systemControls   = [],
+      volumesFrom      = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "ecs/development",
+          "awslogs-region" : "${var.aws_region}",
+          "awslogs-stream-prefix" : "layer8server"
+        },
+      },
+      user    = "0",
+      command = []
+    }
+  ])
+
+  tags = {
+    Name = "layer8-server"
+  }
+}
+
+resource "aws_ecs_service" "service" {
+  name            = "layer8-server"
+  cluster         = data.terraform_remote_state.network.outputs.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.task_definition.arn
+  desired_count   = 1
+
+  deployment_circuit_breaker {
+    enable   = "true"
+    rollback = "false"
+  }
+
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups  = [data.terraform_remote_state.network.outputs.node_security_group_id]
+    subnets          = data.terraform_remote_state.network.outputs.private_subnets[*].id
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = data.terraform_remote_state.network.outputs.service_spot_capacity_provider_name
+    base              = 1
+    weight            = 100
+  }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  force_new_deployment = true
+
+  triggers = {
+    redeployment = plantimestamp()
+  }
+
+  depends_on = [aws_ecs_task_definition.task_definition]
+}

--- a/infra/development/layer8/variables.tf
+++ b/infra/development/layer8/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_region" {
+  default = "ap-southeast-2"
+}
+
+variable "ecr_repository_url" {
+  description = "The URL of the ECR repository"
+}
+
+variable "ecr_image_tag" {
+  description = "The tag of the ECR image"
+}
+
+variable "s3_arn_env_file" {
+  description = "The ARN of the S3 bucket for the environment file"
+}
+
+variable "cloudflare_tunnel_token" {
+  description = "Cloudflare tunnel token"
+}
+
+variable "influxdb_url" {
+  description = "InfluxDB URL"
+}
+
+variable "influxdb_token" {
+  description = "InfluxDB Token"
+}
+
+variable "task_role_arn" {
+  
+}
+
+variable "task_execution_role_arn" {
+  
+}

--- a/infra/development/layer8/variables.tf
+++ b/infra/development/layer8/variables.tf
@@ -27,9 +27,9 @@ variable "influxdb_token" {
 }
 
 variable "task_role_arn" {
-  
+
 }
 
 variable "task_execution_role_arn" {
-  
+
 }

--- a/infra/production/base/main.tf
+++ b/infra/production/base/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  backend "remote" {
+    organization = "globe-and-citizen"
+    workspaces {
+      name = "network-production"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.AWS_REGION
+}
+
+module "network" {
+  source = "./module/network"
+}
+
+module "iam" {
+  source = "./module/iam"
+}
+
+module "ecs" {
+  source                  = "./module/ecs"
+  cluster_name            = "layer8-production"
+  vpc_cidr_block          = module.network.vpc_cidr_block
+  vpc_id                  = module.network.vpc_id
+  subnets                 = module.network.private_subnets
+  iam_profile_arn         = module.iam.iam_profile_arn
+  task_execution_role_arn = module.iam.task_execution_role_arn
+  task_role_arn           = module.iam.task_role_arn
+  aws_region              = var.AWS_REGION
+}
+
+module "ecr" {
+  source = "./module/ecr"
+}
+
+module "s3" {
+  source = "./module/s3"
+}

--- a/infra/production/base/module/ecr/main.tf
+++ b/infra/production/base/module/ecr/main.tf
@@ -1,0 +1,8 @@
+resource "aws_ecr_repository" "layer8_ecr_repo" {
+  name                 = "layer8"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/infra/production/base/module/ecr/outputs.tf
+++ b/infra/production/base/module/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_url" {
+  value = aws_ecr_repository.layer8_ecr_repo.repository_url
+}

--- a/infra/production/base/module/ecs/capacity_provider.tf
+++ b/infra/production/base/module/ecs/capacity_provider.tf
@@ -58,5 +58,11 @@ resource "aws_ecs_capacity_provider" "service_spot_capacity_provider" {
   auto_scaling_group_provider {
     auto_scaling_group_arn         = aws_autoscaling_group.service_spot_asg.arn
     managed_termination_protection = "DISABLED"
+    managed_scaling {
+      maximum_scaling_step_size = 2
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 100
+    }
   }
 }

--- a/infra/production/base/module/ecs/capacity_provider.tf
+++ b/infra/production/base/module/ecs/capacity_provider.tf
@@ -1,0 +1,62 @@
+resource "aws_launch_template" "service_spot_launch_template" {
+  name          = "${aws_ecs_cluster.cluster.name}-service-spot-launch-template"
+  image_id      = data.aws_ssm_parameter.ecs_node_ami.value
+  instance_type = "t3.micro"
+
+  iam_instance_profile { arn = var.iam_profile_arn }
+  monitoring { enabled = false }
+
+  user_data = base64encode(<<-EOF
+      #!/bin/bash
+      echo ECS_CLUSTER=${aws_ecs_cluster.cluster.name} >> /etc/ecs/ecs.config;
+    EOF
+  )
+}
+
+resource "aws_autoscaling_group" "service_spot_asg" {
+  name                = "${aws_ecs_cluster.cluster.name}-service-spot-asg"
+  min_size            = 1
+  max_size            = 1
+  capacity_rebalance  = "true"
+  vpc_zone_identifier = var.subnets[*].id
+
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_allocation_strategy            = "prioritized"
+      on_demand_base_capacity                  = "0"
+      on_demand_percentage_above_base_capacity = "0"
+      spot_allocation_strategy                 = "price-capacity-optimized"
+      spot_instance_pools                      = "0"
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.service_spot_launch_template.id
+        version            = "$Latest"
+      }
+
+      override {
+        instance_type = "t3.micro"
+      }
+
+      override {
+        instance_type = "t3a.micro"
+      }
+    }
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = ""
+    propagate_at_launch = true
+  }
+}
+
+
+resource "aws_ecs_capacity_provider" "service_spot_capacity_provider" {
+  name = "${aws_ecs_cluster.cluster.name}-service-spot-capacity-provider"
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.service_spot_asg.arn
+    managed_termination_protection = "DISABLED"
+  }
+}

--- a/infra/production/base/module/ecs/main.tf
+++ b/infra/production/base/module/ecs/main.tf
@@ -1,0 +1,44 @@
+resource "aws_ecs_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+data "aws_ssm_parameter" "ecs_node_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}
+
+resource "aws_ecs_cluster_capacity_providers" "capacity_provider_mapping" {
+  cluster_name = aws_ecs_cluster.cluster.name
+  capacity_providers = [
+    aws_ecs_capacity_provider.service_spot_capacity_provider.name
+  ]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.service_spot_capacity_provider.name
+    base              = 1
+    weight            = 100
+  }
+}
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name = "ecs/production"
+}
+
+resource "aws_security_group" "ecs_node_sg" {
+  name   = "ecs-node-sg-production"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr_block]
+    description = "vpc cidr"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/infra/production/base/module/ecs/outputs.tf
+++ b/infra/production/base/module/ecs/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_id" {
+  description = "ECS Cluster ID"
+  value       = aws_ecs_cluster.cluster.id
+}
+
+output "service_spot_capacity_provider_name" {
+  description = "ECS Capacity Provider Name for Service"
+  value       = aws_ecs_capacity_provider.service_spot_capacity_provider.name
+}
+
+output "security_group_id" {
+  description = "ECS Security Group ID"
+  value       = aws_security_group.ecs_node_sg.id
+}

--- a/infra/production/base/module/ecs/variables.tf
+++ b/infra/production/base/module/ecs/variables.tf
@@ -1,0 +1,25 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the ECS cluster"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block of the VPC for the ECS cluster"
+}
+
+variable "subnets" {
+  description = "List of the private subnets"
+}
+
+variable "iam_profile_arn" {
+  description = "IAM profile ARN for the ECS cluster"
+}
+
+variable "task_execution_role_arn" {}
+
+variable "task_role_arn" {}
+
+variable "aws_region" {}

--- a/infra/production/base/module/iam/main.tf
+++ b/infra/production/base/module/iam/main.tf
@@ -1,0 +1,67 @@
+data "aws_iam_policy_document" "ecs_node_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_node_role" {
+  name_prefix        = "ecs-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_node_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_node_role_policy" {
+  role       = aws_iam_role.ecs_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_node" {
+  name_prefix = "ecs-iam-profile"
+  path        = "/ecs/instance/"
+  role        = aws_iam_role.ecs_node_role.name
+}
+
+# --- ECS Task Role ---
+
+data "aws_iam_policy_document" "ecs_task_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "ecs-task-role-nonprod"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_doc.json
+}
+
+resource "aws_iam_role" "ecs_exec_role" {
+  name               = "ecs-exec-role-nonprod"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_role_policy" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+
+resource "aws_iam_role_policy_attachment" "ecs_exec_role_policy_ecs" {
+  role       = aws_iam_role.ecs_exec_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_exec_role_policy_s3" {
+  role       = aws_iam_role.ecs_exec_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}

--- a/infra/production/base/module/iam/main.tf
+++ b/infra/production/base/module/iam/main.tf
@@ -41,12 +41,12 @@ data "aws_iam_policy_document" "ecs_task_doc" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-  name               = "ecs-task-role-nonprod"
+  name               = "ecs-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_doc.json
 }
 
 resource "aws_iam_role" "ecs_exec_role" {
-  name               = "ecs-exec-role-nonprod"
+  name               = "ecs-exec-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_doc.json
 }
 

--- a/infra/production/base/module/iam/outputs.tf
+++ b/infra/production/base/module/iam/outputs.tf
@@ -1,0 +1,14 @@
+output "iam_profile_arn" {
+  description = "IAM profile ARN for the ECS cluster"
+  value       = aws_iam_instance_profile.ecs_node.arn
+}
+
+output "task_role_arn" {
+  description = "value"
+  value       = aws_iam_role.ecs_task_role.arn
+}
+
+output "task_execution_role_arn" {
+  description = "value"
+  value       = aws_iam_role.ecs_exec_role.arn
+}

--- a/infra/production/base/module/network/main.tf
+++ b/infra/production/base/module/network/main.tf
@@ -1,0 +1,93 @@
+data "aws_availability_zones" "available" { state = "available" }
+
+locals {
+  azs_count = 2
+  azs_names = data.aws_availability_zones.available.names
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "${terraform.workspace}-vpc"
+  }
+
+  enable_dns_hostnames = true
+}
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.vpc.id
+  count             = local.azs_count
+  cidr_block        = cidrsubnet(aws_vpc.vpc.cidr_block, 2, count.index)
+  availability_zone = local.azs_names[count.index]
+  tags = {
+    Name = "${terraform.workspace}-public-subnet"
+  }
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.vpc.id
+  count             = local.azs_count
+  cidr_block        = cidrsubnet(aws_vpc.vpc.cidr_block, 2, count.index + 2)
+  availability_zone = local.azs_names[count.index]
+  tags = {
+    Name = "${terraform.workspace}-private-subnet"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "${terraform.workspace}-gw"
+  }
+}
+
+resource "aws_eip" "nat" {
+  tags = {
+    Name = "${terraform.workspace}-nat-ip"
+  }
+}
+
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+
+  tags = {
+    Name = "${terraform.workspace}-public-route"
+  }
+}
+resource "aws_route_table_association" "public" {
+  count          = local.azs_count
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+module "fck-nat" {
+  source = "RaJiska/fck-nat/aws"
+
+  name               = "nat-instance"
+  vpc_id             = aws_vpc.vpc.id
+  subnet_id          = aws_subnet.public[0].id
+  eip_allocation_ids = [aws_eip.nat.allocation_id]
+
+  update_route_table = true
+  route_table_id     = aws_route_table.private.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${terraform.workspace}-private-route"
+  }
+}
+
+
+resource "aws_route_table_association" "private" {
+  count          = local.azs_count
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/production/base/module/network/outputs.tf
+++ b/infra/production/base/module/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.vpc.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.vpc.cidr_block
+}
+
+output "public_subnets" {
+  description = "List of the public subnets"
+  value       = aws_subnet.public
+}
+
+output "private_subnets" {
+  description = "List of the private subnets"
+  value       = aws_subnet.private
+}

--- a/infra/production/base/module/s3/main.tf
+++ b/infra/production/base/module/s3/main.tf
@@ -1,0 +1,13 @@
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "awsecsenv"
+  acl    = "private"
+
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+
+  versioning = {
+    enabled = true
+  }
+}

--- a/infra/production/base/outputs.tf
+++ b/infra/production/base/outputs.tf
@@ -1,0 +1,31 @@
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "ecs_cluster_id" {
+  value = module.ecs.cluster_id
+}
+
+output "service_spot_capacity_provider_name" {
+  value = module.ecs.service_spot_capacity_provider_name
+}
+
+output "private_subnets" {
+  value = module.network.private_subnets
+}
+
+output "node_security_group_id" {
+  value = module.ecs.security_group_id
+}
+
+output "task_execution_role_arn" {
+  value = module.iam.task_execution_role_arn
+}
+
+output "task_role_arn" {
+  value = module.iam.task_role_arn
+}
+
+output "ecr_repository_url" {
+  value = module.ecr.repository_url
+}

--- a/infra/production/base/variables.tf
+++ b/infra/production/base/variables.tf
@@ -1,0 +1,4 @@
+variable "AWS_REGION" {
+  description = "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc."
+  default     = "ap-southeast-2"
+}

--- a/infra/production/influxdb/main.tf
+++ b/infra/production/influxdb/main.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "ec2_instance" {
   instance_type = "t3.micro"
   key_name      = "key-pair-one"
 
-  subnet_id     = data.terraform_remote_state.network.outputs.private_subnets[0].id
+  subnet_id              = data.terraform_remote_state.network.outputs.private_subnets[0].id
   vpc_security_group_ids = [data.terraform_remote_state.network.outputs.node_security_group_id]
 
 
@@ -46,7 +46,7 @@ resource "aws_instance" "ec2_instance" {
       echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
       echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
       sudo apt-get update
-      sudo apt-get install influxdb2
+      sudo apt-get install -y influxdb2
       sudo systemctl start influxdb
       sudo systemctl enable influxdb
       

--- a/infra/production/influxdb/main.tf
+++ b/infra/production/influxdb/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  backend "remote" {
+    organization = "globe-and-citizen"
+    workspaces {
+      name = "layer8-influxdb-production"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "globe-and-citizen"
+    workspaces = {
+      name = "network-production"
+    }
+  }
+}
+
+resource "aws_instance" "ec2_instance" {
+  tags = {
+    Name = "influxdb2-production"
+  }
+
+  ami           = "ami-023adaba598e661ac"
+  instance_type = "t3.micro"
+  key_name      = "key-pair-one"
+
+  subnet_id     = data.terraform_remote_state.network.outputs.private_subnets[0].id
+  vpc_security_group_ids = [data.terraform_remote_state.network.outputs.node_security_group_id]
+
+
+  root_block_device {
+    volume_size = 10
+    volume_type = "gp3"
+  }
+
+  user_data = base64encode(<<-EOF
+      #!/bin/bash
+      wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+      echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+      echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
+      sudo apt-get update
+      sudo apt-get install influxdb2
+      sudo systemctl start influxdb
+      sudo systemctl enable influxdb
+      
+      sudo apt-get install cloudflared
+      curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb && 
+      sudo dpkg -i cloudflared.deb
+      sudo cloudflared service install ${var.cloudflare_tunnel_token}
+    EOF
+  )
+}

--- a/infra/production/influxdb/variables.tf
+++ b/infra/production/influxdb/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  default = "ap-southeast-2"
+}
+
+variable "cloudflare_tunnel_token" {}

--- a/infra/production/layer8/main.tf
+++ b/infra/production/layer8/main.tf
@@ -1,0 +1,179 @@
+terraform {
+  backend "remote" {
+    organization = "globe-and-citizen"
+    workspaces {
+      name = "layer8-server-production"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "globe-and-citizen"
+    workspaces = {
+      name = "network-production"
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "task_definition" {
+  family                   = "layer8-server"
+  task_role_arn            = data.terraform_remote_state.network.outputs.task_role_arn
+  execution_role_arn       = data.terraform_remote_state.network.outputs.task_execution_role_arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  skip_destroy             = true
+
+  container_definitions = jsonencode([
+    {
+      name              = "layer8-server",
+      essential         = true,
+      image             = "${var.ecr_repository_url}:${var.ecr_image_tag}",
+      cpu               = 0,
+      memoryReservation = 512,
+      mountPoints       = [],
+      portMappings = [
+        { containerPort = 5001, hostPort = 5001, protocol = "tcp" },
+      ],
+      environment = [],
+      environmentFiles = [
+        { type = "s3", value = var.s3_arn_env_file }
+      ],
+      systemControls = [],
+      volumesFrom    = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "ecs/production",
+          "awslogs-region" : "${var.aws_region}",
+          "awslogs-stream-prefix" : "layer8server"
+        },
+      },
+      user = "0"
+    },
+    {
+      name              = "cloudflared-tunnel",
+      essential         = true,
+      image             = "cloudflare/cloudflared:latest",
+      cpu               = 0,
+      memoryReservation = 128,
+      mountPoints       = [],
+      portMappings      = [],
+      environment       = [],
+      environmentFiles  = [],
+      systemControls    = [],
+      volumesFrom       = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "ecs/production",
+          "awslogs-region" : "${var.aws_region}",
+          "awslogs-stream-prefix" : "layer8tunnel"
+        },
+      },
+      user = "0",
+      command = [
+        "tunnel",
+        "--no-autoupdate",
+        "run",
+        "--token",
+        "${var.cloudflare_tunnel_token}"
+      ]
+    },
+    {
+      name              = "telegraf",
+      essential         = true,
+      image             = "hannmuhammadd/telegraf-opentelemetry-influxdb",
+      cpu               = 0,
+      memoryReservation = 128,
+      mountPoints       = [],
+      portMappings      = [],
+      environment = [
+        {
+          name  = "INFLUXDB_URL",
+          value = "${var.influxdb_url}",
+        },
+        {
+          name  = "INFLUXDB_TOKEN",
+          value = "${var.influxdb_token}",
+        },
+        {
+          name  = "INFLUXDB_ORGANIZATION",
+          value = "layer8",
+        },
+        {
+          name  = "INFLUXDB_BUCKET_NAME",
+          value = "layer8",
+        }
+      ],
+      environmentFiles = [],
+      systemControls   = [],
+      volumesFrom      = [],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "ecs/production",
+          "awslogs-region" : "${var.aws_region}",
+          "awslogs-stream-prefix" : "layer8server"
+        },
+      },
+      user    = "0",
+      command = []
+    }
+  ])
+
+  tags = {
+    Name = "layer8-server"
+  }
+}
+
+resource "aws_ecs_service" "service" {
+  name            = "layer8-server"
+  cluster         = data.terraform_remote_state.network.outputs.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.task_definition.arn
+  desired_count   = 1
+
+  deployment_circuit_breaker {
+    enable   = "true"
+    rollback = "false"
+  }
+
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups  = [data.terraform_remote_state.network.outputs.node_security_group_id]
+    subnets          = data.terraform_remote_state.network.outputs.private_subnets[*].id
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = data.terraform_remote_state.network.outputs.service_spot_capacity_provider_name
+    base              = 1
+    weight            = 100
+  }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  force_new_deployment = true
+
+  triggers = {
+    redeployment = plantimestamp()
+  }
+
+  depends_on = [aws_ecs_task_definition.task_definition]
+}

--- a/infra/production/layer8/variables.tf
+++ b/infra/production/layer8/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  default = "ap-southeast-2"
+}
+
+variable "ecr_repository_url" {
+  description = "The URL of the ECR repository"
+}
+
+variable "ecr_image_tag" {
+  description = "The tag of the ECR image"
+}
+
+variable "s3_arn_env_file" {
+  description = "The ARN of the S3 bucket for the environment file"
+}
+
+variable "cloudflare_tunnel_token" {
+  description = "Cloudflare tunnel token"
+}
+
+variable "influxdb_url" {
+  description = "InfluxDB URL"
+}
+
+variable "influxdb_token" {
+  description = "InfluxDB Token"
+}

--- a/server/main.go
+++ b/server/main.go
@@ -53,6 +53,12 @@ func main() {
 
 	flag.Parse()
 
+	// If the above code block runs, this section is never reached.
+	err := godotenv.Load()
+	if err != nil {
+		log.Fatal("Error loading .env file")
+	}
+
 	// Use flags for using in-memory repository, otherwise app will use database
 	if *port != 8080 && *jwtKey != "" && *MpKey != "" && *UpKey != "" && *ProxyURL != "" {
 		os.Setenv("SERVER_PORT", strconv.Itoa(*port))
@@ -73,12 +79,6 @@ func main() {
 		service := svc.NewService(repository)
 		fmt.Println("Running app with in-memory repository")
 		Server(*port, service, repository) // Run server
-	}
-
-	// If the above code block runs, this section is never reached.
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
 	}
 
 	// If the user has set a database user or password, init the database


### PR DESCRIPTION
The implementation of the AWS infrastructure might seem complex and overkill if it's seen as a solution for just deploying a Layer8 Server. However, some of the implementations here serve as a backbone for any other new product or microservice considering AWS. The implementation offers best practices, secure, cost-efficient, and scalable solutions. When introducing a new service, only a small implementation is required (you'll see no more than 4 new files for a new service to be integrated here).

Deployment Architecture TLDR:

- All AWS resources provisioned via Terraform, Terraform state stored in the Terraform cloud
- Layer8 Server running inside an EC2 Spot Machine, the deployment is managed via ECS (a simplified version of Kubernetes provided by AWS) with 1 GB RAM and 2 Core vCPU
- InfluxDB running inside an EC2 On Demand Machine with 1GB RAM and 2 Core CPU
- DNS and reverse proxy managed by Cloudflare
- InfluxDB and Layer8 Server instances running inside a private subnet without any public IP address. Both instances access the internet via the NAT Instance


Some resources to help with code review : 
- [Terraform Overview](https://www.youtube.com/watch?v=tomUWcQ0P3k&t=35s) to understand basic concepts about terraform and why terraform is a good option.)
- [Detailed video about how terraform work](https://www.youtube.com/watch?v=l5k1ai_GBDE&t=7s) to understand more details about Terraform.
- [Terraform Overview & Syntax Example](https://www.youtube.com/watch?v=HmxkYNv1ksg&t=290s) to understand terraform syntax
- [Article 1](https://www.hashicorp.com/resources/why-consider-terraform-enterprise-over-open-source),  [Article 2](https://medium.com/cloud-native-daily/comparing-terraform-cloud-and-open-source-terraform-for-infrastructure-as-code-27e39d4a5f8d) to understand why terraform cloud is chosen rather than fully using the open source solution
- [ECS Overview from AWS](https://www.youtube.com/watch?v=FnFvpIsBrog) to understand why we should use ECS to manage our layer8 deployment rather than just directly use the EC2 Instance
- [Detailed video about AWS ECS and comparison with Kubernetes](https://www.youtube.com/watch?v=AYAh6YDXuho) to understand more detail about AWS ECS infrastructure
- [Explanation about EC2 Spot 1](https://www.cloudforecast.io/blog/are-aws-spot-instances-worth-it-in-production/)  [Explanation about EC2 Spot 2](https://www.cloudzero.com/blog/spot-instances/) to understand why EC2 SPOT is the best option for Layer8 Server but not for InfluxDB 
- [EC2 Spot Overview video from AWS](https://www.youtube.com/watch?v=aRlY3VBX3Lc) to understand EC2 Spot basic concept
- [Explanation about Cloudflare Reverse Proxy](https://www.cloudflare.com/products/tunnel/) to understand why we use it
- [Basic Concept about how we do networking in AWS](https://www.uturndata.com/2021/02/23/aws-quick-tips-internet-gateways-nat-gateways-and-nat-instances/) to understand the concept of private subnet, public subnet, and NAT
- [Discussion and controversy about why we should have a private subnet](https://stackoverflow.com/questions/22188444/why-do-we-need-private-subnet-in-vpc) to understand why we should put our application in the private subnet besides starting February 2024 AWS costing 2.5$ per month for each public IP address.
- [Discussion started by a user who's annoyed about the high cost of NAT Gateway.](https://www.reddit.com/r/aws/comments/w3zrwz/nat_gateways_are_too_expensive/) to understand why we use NAT Instance rather than NAT Gateway

Cost Estimation per Environment : 
- NAT Instance: 5$
- NAT Public IP Address: 2.5$
- Layer8 Server = 2.30400 (EC2 Spot t3.micro ) + 2.85 (30GB SSD) = 5.1$
- InfluxDB Instance: 7.5 (EC On-Demand t3.micro) + 0.9 (10GB SSD) =  8.4$

Total : 21$ monthly exclude data transfer cost, S3 Storage and ECR storage