### PR TITLE
fixed the issue with login page using the in-memory db

### DIFF
--- a/server/.env.dev
+++ b/server/.env.dev
@@ -10,6 +10,7 @@ UP_999_SECRET_KEY=
 MP_123_SECRET_KEY=
 JWT_SECRET_KEY=secret
 PROXY_URL=http://localhost:5001
+BACKEND_URL=localhost:8000
 
 
 # Production (With RDS)

--- a/server/.env.dev
+++ b/server/.env.dev
@@ -10,7 +10,7 @@ UP_999_SECRET_KEY=
 MP_123_SECRET_KEY=
 JWT_SECRET_KEY=secret
 PROXY_URL=http://localhost:5001
-BACKEND_URL=localhost:8000
+TEST_CLIENT_BACKEND_URL=localhost:8000
 
 
 # Production (With RDS)

--- a/server/internals/repository/repository_test.go
+++ b/server/internals/repository/repository_test.go
@@ -186,14 +186,37 @@ func TestSetClient(t *testing.T) {
 		Secret:      "test_secret",
 		Name:        "test_name",
 		RedirectURI: "test_redirect_uri",
+		BackendURI:  "test_backend_uri",
 		Username:    "test_username",
 		Password:    "test_password",
 		Salt:        "test_salt",
 	}
 
-	mock.ExpectQuery("SELECT (.+) FROM \"clients\" WHERE id = (.+)").WithArgs(client.ID).WillReturnError(gorm.ErrRecordNotFound)
+	mock.ExpectQuery(
+		"SELECT (.+) FROM \"clients\" WHERE id = (.+)",
+	).WithArgs(
+		client.ID,
+	).WillReturnError(
+		gorm.ErrRecordNotFound,
+	)
+
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO \"clients\"")).WithArgs(client.ID, client.Secret, client.Name, client.RedirectURI, client.Username, client.Password, client.Salt).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectExec(
+		regexp.QuoteMeta("INSERT INTO \"clients\""),
+	).WithArgs(
+		client.ID,
+		client.Secret,
+		client.Name,
+		client.RedirectURI,
+		client.BackendURI,
+		client.Username,
+		client.Password,
+		client.Salt,
+	).WillReturnResult(
+		sqlmock.NewResult(1, 1),
+	)
+
 	mock.ExpectCommit()
 
 	// Call the function and check the result

--- a/server/internals/service/service.go
+++ b/server/internals/service/service.go
@@ -225,7 +225,7 @@ func (u *Service) AddTestClient() (*models.Client, error) {
 		Secret:      "absolutelynotasecret!",
 		Name:        "Ex-C",
 		RedirectURI: "http://localhost:5173/oauth2/callback",
-		BackendURI:  os.Getenv("BACKEND_URL"),
+		BackendURI:  os.Getenv("TEST_CLIENT_BACKEND_URL"),
 		Username:    "layer8",
 		Password:    rs_utils.SaltAndHashPassword("12341234", rmSalt),
 		Salt:        rmSalt,

--- a/server/internals/service/service.go
+++ b/server/internals/service/service.go
@@ -9,6 +9,7 @@ import (
 	"globe-and-citizen/layer8/server/internals/repository"
 	"globe-and-citizen/layer8/server/models"
 	"globe-and-citizen/layer8/server/utils"
+	"os"
 	"strings"
 	"time"
 
@@ -224,6 +225,7 @@ func (u *Service) AddTestClient() (*models.Client, error) {
 		Secret:      "absolutelynotasecret!",
 		Name:        "Ex-C",
 		RedirectURI: "http://localhost:5173/oauth2/callback",
+		BackendURI:  os.Getenv("BACKEND_URL"),
 		Username:    "layer8",
 		Password:    rs_utils.SaltAndHashPassword("12341234", rmSalt),
 		Salt:        rmSalt,

--- a/server/models/client.go
+++ b/server/models/client.go
@@ -5,6 +5,7 @@ type Client struct {
 	Secret      string `json:"secret"`
 	Name        string `json:"name"`
 	RedirectURI string `json:"redirect_uri"`
+	BackendURI  string `json:"backend_uri"`
 	Username    string `json:"username"`
 	Password    string `json:"password"`
 	Salt        string `json:"salt"`


### PR DESCRIPTION
The problem was that method GetClientDataByBackendURL within the in-memory repository looked up the client by url, which didn't work because we map client_id -> client_instance. Wrote a simple implementation iterating through the map to find the client for given backend_url.