### PR TITLE
feat: reduce memory reservation of layer8 server container

### DIFF
--- a/infra/development/layer8/main.tf
+++ b/infra/development/layer8/main.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "task_definition" {
       essential         = true,
       image             = "${var.ecr_repository_url}:${var.ecr_image_tag}",
       cpu               = 0,
-      memoryReservation = 512,
+      memoryReservation = 128,
       mountPoints       = [],
       portMappings = [
         { containerPort = 5001, hostPort = 5001, protocol = "tcp" },
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "task_definition" {
       essential         = true,
       image             = "cloudflare/cloudflared:latest",
       cpu               = 0,
-      memoryReservation = 128,
+      memoryReservation = 64,
       mountPoints       = [],
       portMappings      = [],
       environment       = [],

--- a/infra/production/layer8/main.tf
+++ b/infra/production/layer8/main.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "task_definition" {
       essential         = true,
       image             = "${var.ecr_repository_url}:${var.ecr_image_tag}",
       cpu               = 0,
-      memoryReservation = 512,
+      memoryReservation = 128,
       mountPoints       = [],
       portMappings = [
         { containerPort = 5001, hostPort = 5001, protocol = "tcp" },
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "task_definition" {
       essential         = true,
       image             = "cloudflare/cloudflared:latest",
       cpu               = 0,
-      memoryReservation = 128,
+      memoryReservation = 64,
       mountPoints       = [],
       portMappings      = [],
       environment       = [],


### PR DESCRIPTION
memoryReservation is the value used to set how much minimum memory should be allocated to the container in ECS. 

Previously, we set it to 512MB for the Layer8 Server. Because we're using a t3.micro EC2 Instance which only has 900MB of memory, In each deployment ECS will spins up a new EC2 Instance to run a new container, which extends the deployment time. By reducing it to only 128MB + 64MB it prevent ECS from spinning up a new EC2 Instance, ECS can simply use the existing EC2 Instance to run the new container because it still have enough memory to run a new container. 

If you're wondering why ECS doesn't just directly replace the existing container with the new one, it's because ECS aims to ensure zero downtime deployment. Therefore, the existing container is only terminated after the new deployment is verified to be up and running. This behavior is controlled by `deployment_minimum_healthy_percent` field in the service definition.