### PR TITLE
fix: graph ui should not show multiple line

### DIFF
--- a/server/resource_server/repository/stats.go
+++ b/server/resource_server/repository/stats.go
@@ -32,6 +32,7 @@ func (s *StatRepository) GetTotalRequestsInLastXDaysByClient(ctx context.Context
 	|> filter(fn: (r) => r["_measurement"] == "total_byte_transferred")
 	|> filter(fn: (r) => r["_field"] == "counter")
 	|> filter(fn: (r) => r["client_id"] == "%s")
+	|> group(columns: ["client_id"])
 	|> aggregateWindow(every: 1d, fn: sum, createEmpty: true)
 	|> yield(name: "sum")`, days, clientID)
 
@@ -83,6 +84,7 @@ func (s *StatRepository) GetTotalByDateRangeByClient(ctx context.Context, start 
 	|> filter(fn: (r) => r["_measurement"] == "total_byte_transferred")
 	|> filter(fn: (r) => r["client_id"] == "%s")
 	|> filter(fn: (r) => r["_field"] == "counter")
+	|> group(columns: ["client_id"])
 	|> sum()`, start.Format(time.RFC3339), end.Format(time.RFC3339), clientID)
 
 	rawDataFromInflux, err := queryAPI.Query(context.Background(), query)


### PR DESCRIPTION
Root Cause : 
InfluxDB is showing multiple data because the Layer8 server is running on a different machine and the data is split into two different sets, It is fixed by grouping the data based on the client_id, so that multiple data points are summed into a single data point.


Before : 

<img width="1401" alt="image" src="https://github.com/globe-and-citizen/layer8/assets/40066340/17ebbc2a-4496-4c17-aa2b-c8428996fede">

After : 

<img width="1401" alt="image" src="https://github.com/globe-and-citizen/layer8/assets/40066340/91364bf6-15da-43c9-9922-ff6336e0ec21">
