### PR TITLE
fixed user registration at the in-memory db

### DIFF
--- a/server/resource_server/repository/mem_repository.go
+++ b/server/resource_server/repository/mem_repository.go
@@ -38,6 +38,7 @@ func (r *MemoryRepository) RegisterUser(req dto.RegisterUserDTO) error {
 		"last_name":      req.LastName,
 		"country":        req.Country,
 		"display_name":   req.DisplayName,
+		"salt":           rmSalt,
 		"email_verified": "false",
 	}
 	r.storage[req.Username] = map[string]string{


### PR DESCRIPTION
Fixed the issue with login at the user portal when using the in-memory database implementation. The problem was that salt was not properly written to storage, for this reason password validation checks always returned "invalid password".