### PR TITLE
N javokhir patch 1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,36 @@
-SECTION 1: RESOURCE SERVER (http://localhost:5001/)
-[ ] http://localhost:5001/ home page loads
-[ ] "LoginAsUser" button takes you to the user login page
-[ ] SECTION 1: RESOURCE SERVER (http://localhost:5001/)
-[ ] http://localhost:5001/ home page loads
-[ ] "LoginAsUser" button takes you to the user login page
-[ ] Log in using "tester" and "12341234" should succeed
-[ ] Updating the display name should work
-[ ] Log out and Register a new user and try to log in with that new user
-[ ] "LoginAsClient" button takes you to the client login page
-[ ] Log in using "layer8" and "12341234" should work
-[ ] You will be able to see your UID and Secret in profile
-[ ] Log out and Register a new client and log in using that should work
+## Test Cases Checklist
 
-SECTION 2: WEVE GOT POEMS (http://localhost:5173/)
-[ ] Log in with 'tester' / '1234'
-[ ] Log in anonymously with Layer8
-[ ] Clicking "Get Next Poem" loads different poem correctly x 3
-[ ] Clicking "Logout" takes you to the login screen
-[ ] Clicking "Register" takes you to the registration page
-[ ] Registering with a username, password, and profile image is successful
-[ ] Logging in with the new username / password succeeds
-[ ] Logging in with Layer8 opens the pop-up
-[ ] Logging in with the newly registered credentials from Section 1 succeeds
-[ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
-[ ] Clicking "Get Next Poem" loads different poem correctly x 3
-[ ] Clicking "Logout" takes you to the login page
-[ ] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
-[ ] This time, DO NOT share "display name" or "country"
-[ ] Clicking "Get Next Poem" loads different poem correctly x 3
+### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
+- [ ] http://localhost:5001/ home page loads
+- [ ] "LoginAsUser" button takes you to the user login page
+- [ ] Log in using "tester" and "12341234" should succeed
+- [ ] Updating the display name should work
+- [ ] Log out and Register a new user and try to log in with that new user
+- [ ] "LoginAsClient" button takes you to the client login page
+- [ ] Log in using "layer8" and "12341234" should work
+- [ ] You will be able to see your UID and Secret in profile
+- [ ] Log out and Register a new client and log in using that should work
 
-SECTION 3: IMSHARER (http://localhost:5174/)
-[ ] Main page loads
-[ ] Upload of image works
-[ ] Reload leads to instant reload (demonstrating proper caching)
-[ ] Clicking the newly loaded image shows it in a light boxLog in using tester and 12341234 should succeed
+### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
+- [ ] Log in with 'tester' / '1234'
+- [ ] Log in anonymously with Layer8
+- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
+- [ ] Clicking "Logout" takes you to the login screen
+- [ ] Clicking "Register" takes you to the registration page
+- [ ] Registering with a username, password, and profile image is successful
+- [ ] Logging in with the new username / password succeeds
+- [ ] Logging in with Layer8 opens the pop-up
+- [ ] Logging in with the newly registered credentials from Section 1 succeeds
+- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
+- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
+- [ ] Clicking "Logout" takes you to the login page
+- [ ] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
+- [ ] This time, DO NOT share "display name" or "country"
+- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
+
+### SECTION 3: IMSHARER (http://localhost:5174/)
+- [ ] Main page loads
+- [ ] Upload of image works
+- [ ] Reload leads to instant reload (demonstrating proper caching)
+- [ ] Clicking the newly loaded image shows it in a lightbox
+- [ ] Log in using tester and 12341234 should succeed


### PR DESCRIPTION
## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [ ] http://localhost:5001/ home page loads
- [ ] "LoginAsUser" button takes you to the user login page
- [ ] Log in using "tester" and "12341234" should succeed
- [ ] Updating the display name should work
- [ ] Log out and Register a new user and try to log in with that new user
- [ ] "LoginAsClient" button takes you to the client login page
- [ ] Log in using "layer8" and "12341234" should work
- [ ] You will be able to see your UID and Secret in profile
- [ ] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [ ] Log in with 'tester' / '1234'
- [ ] Log in anonymously with Layer8
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
- [ ] Clicking "Logout" takes you to the login screen
- [ ] Clicking "Register" takes you to the registration page
- [ ] Registering with a username, password, and profile image is successful
- [ ] Logging in with the new username / password succeeds
- [ ] Logging in with Layer8 opens the pop-up
- [ ] Logging in with the newly registered credentials from Section 1 succeeds
- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
- [ ] Clicking "Logout" takes you to the login page
- [ ] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [ ] This time, DO NOT share "display name" or "country"
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [ ] Main page loads
- [ ] Upload of image works
- [ ] Reload leads to instant reload (demonstrating proper caching)
- [ ] Clicking the newly loaded image shows it in a lightbox
- [ ] Log in using tester and 12341234 should succeed
