### PR TITLE
Returning exact status codes from service provider

### DIFF
--- a/server/handlers/tunnel.go
+++ b/server/handlers/tunnel.go
@@ -213,8 +213,8 @@ func Tunnel(w http.ResponseWriter, r *http.Request) {
 
 	_, err = utilities.VerifyStandardToken(mpJWT, os.Getenv("MP_123_SECRET_KEY"))
 	if err != nil {
-		fmt.Println("MP JWT verify error: ", err.Error())
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		fmt.Printf("MP JWT verify error: %s. With status code: %d and text: %s", err.Error(), res.StatusCode, res.Status)
+		http.Error(w, res.Status, res.StatusCode)
 		return
 	}
 


### PR DESCRIPTION
## PR Description

This PR fixes globe-and-citizen/layer8-middleware#12. This had to be resolved here because it turned out to be impossible to fix from the middleware.

There are two options to resolve this, the first is requiring that all service providers put a 404 error middleware at the end of their routes so that the `.send` method can be explicitly called:
```js
// This should be added after all your routes
app.use((req, res, next) => {
  res.status(404).send('Sorry, page not found');
});
```
This is not the best option because we don't want to force them to do that. For some, they might just want `expressjs` to handle that for them, or they might forget just like we did for the `wgp` and `imsharer` mocks. For that reason, we want to be able to properly handle it regardless.

When a request to an undefined path comes in, `expressjs` throws and returns a `404` error without using the `send` or the `json` methods which we're intercepting in the middleware, so we're unable to catch them. However, the error is returned exactly as it is back to the proxy as shown in the screenshot attached to the issue linked to this PR.

This leaves us with the second option, which is handling that in the proxy. The perfect spot I found in the `Tunnel` is the point of verifying the `mp-jwt`. **Reason**: If the `mp-jwt` fails verification, and since it is generated and comes from the middleware, we should let it (middleware) handle its failure or decide its own fate ;) as there could be a reason known only by it.

So, rather than returning a generic 401 error when the verification fails, the error from the middleware/service provider is still what we return to the client. However, the full details of the error are logged and can be reviewed by developers internally

## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the newly registered credentials from Section 1 succeeds
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
- [x] Log in using tester and 12341234 should succeed
