### PR TITLE
bug fix trivial changes to README.MD to debugg the PRs on Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ web_modules/
 .env.test.local
 .env.production.local
 .env.local
+.env.secret
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Layer8
+# Layer8 Setup Instructions
 
 This repo contains the Layer8 Resource/Authentication Server, Proxy, and Service Provider Mocks.
 
@@ -247,5 +247,6 @@ app.post("/route", async (req, res) => {
 
 Note: During routine usage, there are no special calls necessary to make use of Layer8. The res.json() & res.send() & res.end() have been overwritten by Layer8 and will be used automatically. 
 
-### Warnings and Gotcha's
+### Warnings and Gotcha's To Consider
 1) Using express.json() as middleware in main file is unnecessary. The layer8_middleware automatically parses the incoming request. If you include the line app.use(express.json()) requests will get "caught" in the express.json() middleware and not reach your other endpoints.
+

--- a/sp_mocks/wgp/backend/server.js
+++ b/sp_mocks/wgp/backend/server.js
@@ -20,8 +20,8 @@ const LAYER8_CALLBACK_URL = `${FRONTEND_URL}/oauth2/callback`;
 const LAYER8_RESOURCE_URL = `${LAYER8_URL}/api/user`;
 
 const layer8Auth = new ClientOAuth2({
-  clientId: "notanid",
-  clientSecret: "absolutelynotasecret!",
+  clientId: "f0fe2f3f-cabe-4d44-a8d4-ed7154627867",
+  clientSecret: "b85bc41f06a0f86b912a51a9688a3c78fb464e9b7ac692eff145f20e4bcae3e8",
   accessTokenUri: `${LAYER8_URL}/api/oauth`,
   authorizationUri: `${LAYER8_URL}/authorize`,
   redirectUri: LAYER8_CALLBACK_URL,


### PR DESCRIPTION
## Description
This PR updates the README.MD. In order to maintain consistency between the readme and the code, two other files are also changed: `.gitignore` and `sp_mocks/wgp/backend/server.js`


## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [ ] !!Logging in with the newly registered credentials from Section 1 succeeds!! See issue #83 
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
***- [ ] Log in using tester and 12341234 should succeed ***
