### PR TITLE
removed email from db

### DIFF
--- a/migrations/000001_init.up.sql
+++ b/migrations/000001_init.up.sql
@@ -13,7 +13,6 @@ CREATE TABLE clients (
 
 CREATE TABLE users (
     id BIGSERIAL,
-    email character varying(255) NOT NULL UNIQUE,
     username character varying(50) NOT NULL UNIQUE,
     password character varying(255) NOT NULL,
     first_name character varying(50) NOT NULL,

--- a/server/assets-v1/templates/src/pages/user_portal/email/input-verification-code.html
+++ b/server/assets-v1/templates/src/pages/user_portal/email/input-verification-code.html
@@ -58,6 +58,12 @@
             const token = ref(localStorage.getItem("token") || null);
 
             const checkEmailVerificationCode = async () => {
+                if (verificationCode.value === "") {
+                    alert("Verification code is mandatory");
+                    return;
+                }
+                const email = localStorage.getItem("email");
+
                 const response = await window.fetch(
                     "[[ .ProxyURL ]]/api/v1/check-email-verification-code",
                     {
@@ -67,11 +73,14 @@
                             Authorization: `Bearer ${token.value}`,
                         },
                         body: JSON.stringify({
+                            email: email,
                             code: verificationCode.value,
                         }),
-                    }
+                    },
                 );
                 const result = await response.json();
+
+                localStorage.removeItem("email");
 
                 alert(result.message);
 

--- a/server/assets-v1/templates/src/pages/user_portal/email/input-your-email.html
+++ b/server/assets-v1/templates/src/pages/user_portal/email/input-your-email.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link
+                rel="stylesheet"
+                href="/assets-v1/templates/assets/styles/output.css"
+        />
+        <link
+                rel="stylesheet"
+                href="/assets-v1/templates/assets/styles/base.css"
+        />
+        <title>Let's verify your email</title>
+        <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+    </head>
+
+    <body>
+        <div id="app">
+            <div id="navbar" class="user-container">
+                <div class="bg-white flex justify-center items-center my-4">
+                    <img
+                            src="../assets-v1/images/L8Logo.png"
+                            alt="Layer8"
+                            width="250"
+                            height="535"
+                    />
+                </div>
+            </div>
+
+            <div id="body" class="bg-[#F6F8FF] md:grid md:grid-cols-2">
+                <div class="self-center py-4 mx-10 lg:mx-36">
+                    <div class="mb-6">
+                        <label class="text-lg text-[#414141] mb-1 block">Input your email:</label>
+                        <input
+                                class="w-full bg-white rounded-md border border-[#EADFD8] py-2.5 px-3 placeholder:text-[#414141] focus:outline-none"
+                                placeholder="email"
+                                v-model="emailAddress">
+                    </div>
+
+                    <button
+                            class="w-[70%] bg-[#4F80E1] rounded-lg text-center text-white py-4 mb-12"
+                            @click="getVerificationCode"
+                    >
+                        Get code
+                    </button>
+                </div>
+
+                <div class="bg-white hidden md:flex items-center">
+                    <img src="/assets-v1/templates/assets/images/client-image.png" />
+                </div>
+            </div>
+        </div>
+
+        <script>
+            const { createApp, computed, ref } = Vue;
+            const emailAddress = ref("");
+            const token = ref(localStorage.getItem("token") || null);
+
+            const getVerificationCode = async () => {
+                if (emailAddress.value === "") {
+                    alert("Email address is mandatory");
+                    return;
+                }
+                localStorage.setItem("email", emailAddress.value);
+
+                try {
+                    const response = await window.fetch(
+                        "[[ .ProxyURL ]]/api/v1/verify-email",
+                        {
+                            method: "POST",
+                            headers: {
+                                "Content-Type": "application/json",
+                                Authorization: `Bearer ${token.value}`,
+                            },
+                            body: JSON.stringify({
+                                email: emailAddress.value,
+                            }),
+                        },
+                    );
+
+                    const result = await response.json();
+
+                    if (result.message === "OK!") {
+                        window.location.href = "[[ .ProxyURL ]]/input-verification-code-page";
+                    } else {
+                        alert("Error happened: " + result.errors);
+                    }
+                } catch (error) {
+                    console.error(error);
+                }
+            };
+
+            const app = createApp({
+                setup() {
+                    return {
+                        getVerificationCode,
+                        emailAddress,
+                    };
+                },
+            });
+
+            app.mount("#app");
+        </script>
+    </body>
+</html>

--- a/server/assets-v1/templates/src/pages/user_portal/profile.html
+++ b/server/assets-v1/templates/src/pages/user_portal/profile.html
@@ -160,10 +160,6 @@
                   <input class="border border-[#BDC3CA] rounded-lg bg-[#ECF4FD] px-2 md:px-3 lg:px-5 py-2 md:py-3 lg:py-4 text-start text-base text-[#8F8F8F] focus:outline-none w-full" readonly :value="user.country" />
                 </div>
                 <div>
-                  <label class="font-normal text-black text-sm text-start mb-2 block">Email</label>
-                  <input class="border border-[#BDC3CA] rounded-lg bg-[#ECF4FD] px-2 md:px-3 lg:px-5 py-2 md:py-3 lg:py-4 text-start text-base text-[#8F8F8F] focus:outline-none w-full" readonly :value="user.email" />
-                </div>
-                <div>
                   <label class="font-normal text-black text-sm text-start mb-2 block">Display Name</label>
                   <input class="border border-[#BDC3CA] rounded-lg px-2 md:px-3 lg:px-5 py-2 md:py-3 lg:py-4 text-start text-base text-[#8F8F8F] focus:outline-none w-full" type="text" v-model="newDisplayName" />
                 </div>
@@ -197,7 +193,6 @@
 
       const token = ref(localStorage.getItem("token") || null);
       const user = ref({
-        email: "",
         username: "",
         first_name: "",
         last_name: "",
@@ -235,27 +230,7 @@
       };
 
       const verifyEmail = async () => {
-        try {
-            const response = await window.fetch(
-            "[[ .ProxyURL ]]/api/v1/verify-email",
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "Application/Json",
-                Authorization: `Bearer ${token.value}`,
-              },
-            }
-            );
-            const data = await response.json();
-
-            if (data.message === "OK!") {
-                window.location.href = "[[ .ProxyURL ]]/verify-email-page"
-            } else {
-                alert("Error happened: " + data.errors)
-            }
-        } catch (error) {
-          console.error(error);
-        }
+          window.location.href = "[[ .ProxyURL ]]/input-your-email-page";
       };
 
       const changeDisplayName = async () => {

--- a/server/assets-v1/templates/src/pages/user_portal/register.html
+++ b/server/assets-v1/templates/src/pages/user_portal/register.html
@@ -36,14 +36,6 @@
           </p>
           <div>
             <div class="mb-3">
-              <label class="text-sm text-[#414141] mb-1 block">Email</label>
-              <input
-                class="w-full bg-white rounded-md border border-[#EADFD8] py-2.5 px-3 placeholder:text-[#414141] focus:outline-none"
-                v-model="registerEmail"
-                placeholder="Email"
-              />
-            </div>
-            <div class="mb-3">
               <label class="text-sm text-[#414141] mb-1 block">Username</label>
               <input
                 class="w-full bg-white rounded-md border border-[#EADFD8] py-2.5 px-3 placeholder:text-[#414141] focus:outline-none"
@@ -138,7 +130,6 @@
 
     <script>
       const { createApp, computed, ref } = Vue;
-      const registerEmail = ref("");
       const registerUsername = ref("");
       const registerPassword = ref("");
       const registerFirstName = ref("");
@@ -150,7 +141,7 @@
 
       const registerUser = async () => {
         try {
-          if (registerUsername.value == "" || registerPassword.value == "" || registerEmail.value == "" || registerFirstName.value == "" || registerLastName.value == "" || registerDisplayName.value == "" || registerCountry.value  == "") {
+          if (registerUsername.value == "" || registerPassword.value == "" || registerFirstName.value == "" || registerLastName.value == "" || registerDisplayName.value == "" || registerCountry.value  == "") {
             showToastMessage("Please enter all details!", "error");
             return;
           }
@@ -160,7 +151,6 @@
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              email: registerEmail.value,
               username: registerUsername.value,
               first_name: registerFirstName.value,
               last_name: registerLastName.value,
@@ -196,7 +186,6 @@
         setup() {
           return {
             registerUser,
-            registerEmail,
             registerUsername,
             registerFirstName,
             registerLastName,

--- a/server/cmd/app/main.go
+++ b/server/cmd/app/main.go
@@ -84,7 +84,6 @@ func main() {
 
 		resourceRepository = rsRepo.NewMemoryRepository()
 		resourceRepository.RegisterUser(dto.RegisterUserDTO{
-			Email:       "user@test.com",
 			Username:    "tester",
 			FirstName:   "Test",
 			LastName:    "User",
@@ -195,8 +194,10 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 				Ctl.LoginUserPage(w, r)
 			case path == "/user-register-page":
 				Ctl.RegisterUserPage(w, r)
-			case path == "/verify-email-page":
-				Ctl.VerifyEmailPage(w, r)
+			case path == "/input-your-email-page":
+				Ctl.InputYourEmailPage(w, r)
+			case path == "/input-verification-code-page":
+				Ctl.InputVerificationCodePage(w, r)
 			case path == "/client-register-page":
 				Ctl.ClientHandler(w, r)
 			case path == "/client-login-page":

--- a/server/cmd/setup/setup.go
+++ b/server/cmd/setup/setup.go
@@ -104,7 +104,6 @@ func SetupPG() {
 	if os.Getenv("CREATE_TEST_USER") == "true" {
 		resourceRepository.RegisterUser(
 			dto.RegisterUserDTO{
-				Email:       os.Getenv("TEST_USER_EMAIL"),
 				Password:    os.Getenv("TEST_USER_PASSWORD"),
 				Username:    os.Getenv("TEST_USER_USERNAME"),
 				FirstName:   os.Getenv("TEST_USER_FIRST_NAME"),

--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -314,8 +314,8 @@ func CheckEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
 
 	response := utils.BuildResponse(
 		true,
-		"OK!",
 		"Your email was successfully verified!",
+		"Email verified!",
 	)
 	e = json.NewEncoder(w).Encode(response)
 	if e != nil {

--- a/server/resource_server/controller/controller_test.go
+++ b/server/resource_server/controller/controller_test.go
@@ -26,6 +26,7 @@ var authenticationToken, _ = utils.GenerateToken(
 
 const verificationCode = "123467"
 const emailProof = "email_proof"
+const userEmail = "user@email.com"
 
 func decodeResponseBody(t *testing.T, rr *httptest.ResponseRecorder) utils.Response {
 	var response utils.Response
@@ -37,7 +38,7 @@ func decodeResponseBody(t *testing.T, rr *httptest.ResponseRecorder) utils.Respo
 
 // MockService implements interfaces.IService for testing purposes.
 type MockService struct {
-	verifyEmail                        func(userID uint) error
+	verifyEmail                        func(userID uint, userEmail string) error
 	checkEmailVerificationCode         func(userID uint, code string) error
 	generateZkProofOfEmailVerification func(userID uint) (string, error)
 	saveProofOfEmailVerification       func(userID uint, verificationCode string, zkProof string) error
@@ -66,7 +67,6 @@ func (ms *MockService) LoginUser(req dto.LoginUserDTO) (models.LoginUserResponse
 func (ms *MockService) ProfileUser(userID uint) (models.ProfileResponseOutput, error) {
 	if userID == 1 {
 		return models.ProfileResponseOutput{
-			Email:       "test@gcitizen.com",
 			Username:    "test_user",
 			FirstName:   "Test",
 			LastName:    "User",
@@ -77,8 +77,8 @@ func (ms *MockService) ProfileUser(userID uint) (models.ProfileResponseOutput, e
 	return models.ProfileResponseOutput{}, fmt.Errorf("user not found")
 }
 
-func (ms *MockService) VerifyEmail(userID uint) error {
-	return ms.verifyEmail(userID)
+func (ms *MockService) VerifyEmail(userID uint, userEmail string) error {
+	return ms.verifyEmail(userID, userEmail)
 }
 
 func (ms *MockService) CheckEmailVerificationCode(userID uint, code string) error {
@@ -328,7 +328,6 @@ func TestProfileHandler(t *testing.T) {
 	}
 
 	// Now assert the fields directly
-	assert.Equal(t, "test@gcitizen.com", response.Email)
 	assert.Equal(t, "test_user", response.Username)
 	assert.Equal(t, "Test", response.FirstName)
 	assert.Equal(t, "User", response.LastName)
@@ -372,15 +371,88 @@ func TestGetClientData(t *testing.T) {
 	assert.Equal(t, "https://gcitizen.com/callback", response.RedirectURI)
 }
 
+func TestVerifyEmailHandler_InvalidAuthorizationToken(t *testing.T) {
+	requestBody := []byte(`{"email": "user@email.com"}`)
+	req, err := http.NewRequest("POST", "/api/v1/verify-email", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer invalid token")
+
+	req = req.WithContext(context.WithValue(req.Context(), "service", &MockService{}))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.VerifyEmailHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Request failed: invalid authorization token", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestVerifyEmailHandler_MalformedRequestBodyJson(t *testing.T) {
+	requestBody := []byte(`{"email": "user@email.com";}`)
+	req, err := http.NewRequest("POST", "/api/v1/verify-email", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+authenticationToken)
+
+	req = req.WithContext(context.WithValue(req.Context(), "service", &MockService{}))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.VerifyEmailHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Request malformed: error while parsing json", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestVerifyEmailHandler_RequestJsonSchemeIsInvalid(t *testing.T) {
+	requestBody := []byte(`{"emal": "user@email.com"}`)
+	req, err := http.NewRequest("POST", "/api/v1/verify-email", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+authenticationToken)
+
+	req = req.WithContext(context.WithValue(req.Context(), "service", &MockService{}))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.VerifyEmailHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
 func TestVerifyEmailHandler_FailedToVerifyEmail(t *testing.T) {
-	req, err := http.NewRequest("GET", "/api/v1/verify-email", nil)
+	requestBody := []byte(`{"email": "user@email.com"}`)
+	req, err := http.NewRequest("POST", "/api/v1/verify-email", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Authorization", "Bearer "+authenticationToken)
 
 	mockService := &MockService{
-		verifyEmail: func(userID uint) error {
+		verifyEmail: func(userID uint, email string) error {
+			if email != userEmail {
+				t.Fatalf("User email mismatch: expected %s, got %s", userEmail, email)
+			}
 			return fmt.Errorf("failed to verify email for user %d", userID)
 		},
 	}
@@ -400,14 +472,18 @@ func TestVerifyEmailHandler_FailedToVerifyEmail(t *testing.T) {
 }
 
 func TestVerifyEmailHandler_Success(t *testing.T) {
-	req, err := http.NewRequest("GET", "/api/v1/verify-email", nil)
+	requestBody := []byte(`{"email": "user@email.com"}`)
+	req, err := http.NewRequest("POST", "/api/v1/verify-email", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Authorization", "Bearer "+authenticationToken)
 
 	mockService := &MockService{
-		verifyEmail: func(userID uint) error {
+		verifyEmail: func(userID uint, email string) error {
+			if email != userEmail {
+				t.Fatalf("User email mismatch: expected %s, got %s", userEmail, email)
+			}
 			return nil
 		},
 	}
@@ -428,7 +504,10 @@ func TestVerifyEmailHandler_Success(t *testing.T) {
 }
 
 func TestCheckEmailVerificationCode_InvalidAuthenticationToken(t *testing.T) {
-	requestBody := []byte(`{"code": "123467"}`)
+	requestBody := []byte(`{
+		"email": "user@email.com",
+		"code": "123467"
+	}`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
@@ -452,7 +531,10 @@ func TestCheckEmailVerificationCode_InvalidAuthenticationToken(t *testing.T) {
 }
 
 func TestCheckEmailVerificationCode_MalformedRequestBody(t *testing.T) {
-	requestBody := []byte(`{"code": "123467"`)
+	requestBody := []byte(`{
+		"email": "user@email.com",
+		"code": "123467"
+	`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
@@ -476,7 +558,10 @@ func TestCheckEmailVerificationCode_MalformedRequestBody(t *testing.T) {
 }
 
 func TestCheckEmailVerificationCode_RequestJSONDoesNotMatchTheScheme(t *testing.T) {
-	requestBody := []byte(`{"cod": "123467"}`)
+	requestBody := []byte(`{
+		"email": "user@email.com",
+		"cod": "123467"
+	}`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
@@ -500,7 +585,10 @@ func TestCheckEmailVerificationCode_RequestJSONDoesNotMatchTheScheme(t *testing.
 }
 
 func TestCheckEmailVerificationCode_VerificationCodeIsInvalid(t *testing.T) {
-	requestBody := []byte(`{"code": "123467"}`)
+	requestBody := []byte(`{
+		"email": "user@email.com", 
+		"code": "123467"
+	}`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
@@ -531,7 +619,10 @@ func TestCheckEmailVerificationCode_VerificationCodeIsInvalid(t *testing.T) {
 }
 
 func TestCheckEmailVerificationCode_ZkEmailProofFailedToBeGenerated(t *testing.T) {
-	requestBody := []byte(`{"code": "123467"}`)
+	requestBody := []byte(`{
+		"email": "user@email.com", 
+		"code": "123467"
+	}`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
@@ -565,7 +656,10 @@ func TestCheckEmailVerificationCode_ZkEmailProofFailedToBeGenerated(t *testing.T
 }
 
 func TestCheckEmailVerificationCode_FailedToSaveProofOfEmailVerification(t *testing.T) {
-	requestBody := []byte(`{"code": "123467"}`)
+	requestBody := []byte(`{
+		"email": "user@email.com", 
+		"code": "123467"
+	}`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)
@@ -607,7 +701,10 @@ func TestCheckEmailVerificationCode_FailedToSaveProofOfEmailVerification(t *test
 }
 
 func TestCheckEmailVerificationCode_Success(t *testing.T) {
-	requestBody := []byte(`{"code": "123467"}`)
+	requestBody := []byte(`{
+		"email": "user@email.com", 
+		"code": "123467"
+	}`)
 	req, err := http.NewRequest("POST", "/api/v1/check-email-verification-code", bytes.NewBuffer(requestBody))
 	if err != nil {
 		t.Fatal(err)

--- a/server/resource_server/controller/controller_test.go
+++ b/server/resource_server/controller/controller_test.go
@@ -135,8 +135,8 @@ func (ms *MockService) GetClientDataByBackendURL(backendURL string) (models.Clie
 }
 
 func (ms *MockService) CheckBackendURI(backendURL string) (bool, error) {
-    // Mock implementation for testing purposes.
-    return true, nil
+	// Mock implementation for testing purposes.
+	return true, nil
 }
 
 func TestRegisterUserHandler(t *testing.T) {
@@ -741,8 +741,8 @@ func TestCheckEmailVerificationCode_Success(t *testing.T) {
 	response := decodeResponseBody(t, rr)
 
 	assert.True(t, response.Status)
-	assert.Equal(t, "OK!", response.Message)
-	assert.Equal(t, "Your email was successfully verified!", response.Data)
+	assert.Equal(t, "Your email was successfully verified!", response.Message)
+	assert.Equal(t, "Email verified!", response.Data)
 	assert.Nil(t, response.Error)
 }
 
@@ -872,4 +872,5 @@ func setMockServiceInContext(req *http.Request) *http.Request {
 	ctx := context.WithValue(req.Context(), "service", mockSvc)
 	return req.WithContext(ctx)
 }
+
 // Javokhir finished the testing

--- a/server/resource_server/dto/dto.go
+++ b/server/resource_server/dto/dto.go
@@ -1,7 +1,6 @@
 package dto
 
 type RegisterUserDTO struct {
-	Email       string `json:"email" validate:"required,email"`
 	Username    string `json:"username" validate:"required,min=3,max=50"`
 	Password    string `json:"password" validate:"required"`
 	FirstName   string `json:"first_name" validate:"required"`
@@ -40,6 +39,12 @@ type RegisterClientDTO struct {
 type CheckBackendURIDTO struct {
 	BackendURI string `json:"backend_uri" validate:"required"`
 }
+
+type VerifyEmailDTO struct {
+	Email string `json:"email" validate:"required,email"`
+}
+
 type CheckEmailVerificationCodeDTO struct {
-	Code string `json:"code" validate:"required"`
+	Email string `json:"email" validate:"required,email"`
+	Code  string `json:"code" validate:"required"`
 }

--- a/server/resource_server/emails/verification/verifier.go
+++ b/server/resource_server/emails/verification/verifier.go
@@ -38,15 +38,17 @@ func NewEmailVerifier(
 	return verifier
 }
 
-func (v *EmailVerifier) GenerateVerificationCode(user *models.User) string {
-	return v.codeGenerator.GenerateCode(user.Email)
+func (v *EmailVerifier) GenerateVerificationCode(user *models.User, userEmail string) string {
+	return v.codeGenerator.GenerateCode(userEmail)
 }
 
-func (v *EmailVerifier) SendVerificationEmail(user *models.User, verificationCode string) error {
+func (v *EmailVerifier) SendVerificationEmail(
+	user *models.User, userEmail string, verificationCode string,
+) error {
 	return v.emailSenderService.SendEmail(
 		&models.Email{
 			From:    v.adminEmailAddress,
-			To:      user.Email,
+			To:      userEmail,
 			Subject: "Verify your email at the Layer8 service",
 			Content: models.VerificationEmailContent{
 				Username: user.Username,

--- a/server/resource_server/emails/verification/verifier_test.go
+++ b/server/resource_server/emails/verification/verifier_test.go
@@ -59,8 +59,8 @@ func TestGenerateVerificationCode(t *testing.T) {
 		&models.User{
 			ID:       userId,
 			Username: username,
-			Email:    userEmail,
 		},
+		userEmail,
 	)
 
 	assert.Equal(t, generatedCode, verificationCode)
@@ -80,8 +80,8 @@ func TestSendVerificationEmail(t *testing.T) {
 		&models.User{
 			ID:       userId,
 			Username: username,
-			Email:    userEmail,
 		},
+		userEmail,
 		verificationCode,
 	)
 

--- a/server/resource_server/interfaces/service.go
+++ b/server/resource_server/interfaces/service.go
@@ -13,7 +13,7 @@ type IService interface {
 	LoginClient(req dto.LoginClientDTO) (models.LoginUserResponseOutput, error)
 	ProfileUser(userID uint) (models.ProfileResponseOutput, error)
 	ProfileClient(userID string) (models.ClientResponseOutput, error)
-	VerifyEmail(userID uint) error
+	VerifyEmail(userID uint, userEmail string) error
 	CheckEmailVerificationCode(userID uint, code string) error
 	GenerateZkProofOfEmailVerification(userID uint) (string, error)
 	SaveProofOfEmailVerification(userID uint, verificationCode string, zkProof string) error

--- a/server/resource_server/models/response.go
+++ b/server/resource_server/models/response.go
@@ -10,7 +10,6 @@ type LoginUserResponseOutput struct {
 }
 
 type ProfileResponseOutput struct {
-	Email         string `json:"email"`
 	Username      string `json:"username"`
 	FirstName     string `json:"first_name"`
 	LastName      string `json:"last_name"`

--- a/server/resource_server/models/user.go
+++ b/server/resource_server/models/user.go
@@ -2,7 +2,6 @@ package models
 
 type User struct {
 	ID               uint   `gorm:"primaryKey; unique; autoIncrement; not null" json:"id"`
-	Email            string `gorm:"column:email; unique; not null" json:"email"`
 	Username         string `gorm:"column:username; unique; not null" json:"username"`
 	Password         string `gorm:"column:password; not null" json:"password"`
 	FirstName        string `gorm:"column:first_name; not null" json:"first_name"`

--- a/server/resource_server/repository/mem_repository.go
+++ b/server/resource_server/repository/mem_repository.go
@@ -33,7 +33,6 @@ func (r *MemoryRepository) RegisterUser(req dto.RegisterUserDTO) error {
 	key := fmt.Sprintf("%s:%s", req.Username, req.Password)
 	r.storage[key] = map[string]string{
 		"user_id":           userID,
-		"email":             req.Email,
 		"username":          req.Username,
 		"password":          HashedAndSaltedPass,
 		"first_name":        req.FirstName,
@@ -95,7 +94,6 @@ func (r *MemoryRepository) FindUser(userId uint) (models.User, error) {
 
 	return models.User{
 		ID:               userId,
-		Email:            userData["email"],
 		Username:         userData["username"],
 		Password:         userData["password"],
 		FirstName:        userData["first_name"],
@@ -141,7 +139,6 @@ func (r *MemoryRepository) LoginUser(req dto.LoginUserDTO) (models.User, error) 
 	}
 	user := models.User{
 		ID:        uint(userIdUint),
-		Email:     r.storage[key]["email"],
 		Username:  r.storage[key]["username"],
 		Password:  r.storage[key]["password"],
 		FirstName: r.storage[key]["first_name"],
@@ -178,7 +175,6 @@ func (r *MemoryRepository) ProfileUser(userID uint) (models.User, []models.UserM
 	password := r.storage[fmt.Sprintf("%d", userID)]["password"]
 	user := models.User{
 		ID:        userID,
-		Email:     r.storage[password]["email"],
 		Username:  r.storage[password]["username"],
 		Password:  r.storage[password]["password"],
 		FirstName: r.storage[password]["first_name"],

--- a/server/resource_server/repository/repository.go
+++ b/server/resource_server/repository/repository.go
@@ -23,12 +23,10 @@ func NewRepository(db *gorm.DB) interfaces.IRepository {
 }
 
 func (r *Repository) RegisterUser(req dto.RegisterUserDTO) error {
-
 	rmSalt := utils.GenerateRandomSalt(utils.SaltSize)
 	HashedAndSaltedPass := utils.SaltAndHashPassword(req.Password, rmSalt)
 
 	user := models.User{
-		Email:     req.Email,
 		Username:  req.Username,
 		Password:  HashedAndSaltedPass,
 		FirstName: req.FirstName,

--- a/server/resource_server/repository/repository_test.go
+++ b/server/resource_server/repository/repository_test.go
@@ -17,7 +17,7 @@ import (
 
 const id uint = 1
 const userId uint = 1
-const userEmail = "example@test.com"
+const username = "username"
 const verificationCode = "123456"
 const emailProof = "AbcdfTs"
 
@@ -68,7 +68,6 @@ func TestRegisterUser(t *testing.T) {
 
 	// Define a test user DTO
 	testUser := dto.RegisterUserDTO{
-		Email:       "test@gcitizen.com",
 		Username:    "test_user",
 		FirstName:   "Test",
 		LastName:    "User",
@@ -160,7 +159,17 @@ func TestLoginPreCheckUser(t *testing.T) {
 	}
 
 	// Expect a query to be executed and return a row
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE username = $1 ORDER BY "users"."id" LIMIT 1`)).WithArgs(testLoginPrecheck.Username).WillReturnRows(sqlmock.NewRows([]string{"id", "email", "username", "first_name", "last_name", "password", "salt"}).AddRow(1, "user@test.com", "test_user", "Test", "User", "testpass", "testsalt"))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "users" WHERE username = $1 ORDER BY "users"."id" LIMIT 1`),
+	).WithArgs(
+		testLoginPrecheck.Username,
+	).WillReturnRows(
+		sqlmock.NewRows(
+			[]string{"id", "username", "first_name", "last_name", "password", "salt"},
+		).AddRow(
+			1, "test_user", "Test", "User", "testpass", "testsalt",
+		),
+	)
 
 	// Call the LoginPreCheckUser function
 	repo.LoginPreCheckUser(testLoginPrecheck)
@@ -188,7 +197,17 @@ func TestProfileUser(t *testing.T) {
 	repo := NewRepository(db)
 
 	// Expect a query to be executed and return a row
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE id = $1 ORDER BY "users"."id" LIMIT 1`)).WithArgs(1).WillReturnRows(sqlmock.NewRows([]string{"id", "email", "username", "first_name", "last_name", "password", "salt"}).AddRow(1, "user@test.com", "test_user", "Test", "User", "testpass", "testsalt"))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(`SELECT * FROM "users" WHERE id = $1 ORDER BY "users"."id" LIMIT 1`),
+	).WithArgs(
+		1,
+	).WillReturnRows(
+		sqlmock.NewRows(
+			[]string{"id", "username", "first_name", "last_name", "password", "salt"},
+		).AddRow(
+			1, "test_user", "Test", "User", "testpass", "testsalt",
+		),
+	)
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "user_metadata" WHERE user_id = $1`)).WithArgs(1).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "key", "value"}).AddRow(1, 1, "email_verified", "true").AddRow(2, 1, "display_name", "user").AddRow(3, 1, "country", "Unknown"))
 
 	// Call the ProfileUser function
@@ -318,7 +337,7 @@ func TestFindUser_UserDoesNotExist(t *testing.T) {
 		userId,
 	).WillReturnRows(
 		sqlmock.NewRows(
-			[]string{"id", "email", "username", "password", "first_name",
+			[]string{"id", "username", "password", "first_name",
 				"last_name", "salt", "email_proof", "verification_code"},
 		),
 	)
@@ -342,9 +361,9 @@ func TestFindUser_Success(t *testing.T) {
 		userId,
 	).WillReturnRows(
 		sqlmock.NewRows(
-			[]string{"id", "email", "username", "password", "first_name",
+			[]string{"id", "username", "password", "first_name",
 				"last_name", "salt", "email_proof", "verification_code"},
-		).AddRow(userId, userEmail, "username", "password", "first_name",
+		).AddRow(userId, username, "password", "first_name",
 			"last_name", "salt", "", "",
 		),
 	)
@@ -356,7 +375,7 @@ func TestFindUser_Success(t *testing.T) {
 	}
 
 	assert.Equal(t, userId, user.ID)
-	assert.Equal(t, userEmail, user.Email)
+	assert.Equal(t, username, user.Username)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("There were unfulfilled expectations: %s", err)

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"github.com/go-playground/validator/v10"
 	"globe-and-citizen/layer8/server/resource_server/dto"
 	"globe-and-citizen/layer8/server/resource_server/emails/verification"
@@ -28,9 +27,6 @@ func NewService(
 }
 
 func (s *service) RegisterUser(req dto.RegisterUserDTO) error {
-	if req.Email == "" {
-		return fmt.Errorf("email is required")
-	}
 	if err := validator.New().Struct(req); err != nil {
 		return err
 	}
@@ -144,7 +140,6 @@ func (s *service) ProfileUser(userID uint) (models.ProfileResponseOutput, error)
 		return models.ProfileResponseOutput{}, err
 	}
 	profileResp := models.ProfileResponseOutput{
-		Email:     user.Email,
 		Username:  user.Username,
 		FirstName: user.FirstName,
 		LastName:  user.LastName,
@@ -177,15 +172,15 @@ func (s *service) ProfileClient(userName string) (models.ClientResponseOutput, e
 	return clientModel, nil
 }
 
-func (s *service) VerifyEmail(userID uint) error {
+func (s *service) VerifyEmail(userID uint, userEmail string) error {
 	user, e := s.repository.FindUser(userID)
 	if e != nil {
 		return e
 	}
 
-	verificationCode := s.emailVerifier.GenerateVerificationCode(&user)
+	verificationCode := s.emailVerifier.GenerateVerificationCode(&user, userEmail)
 
-	e = s.emailVerifier.SendVerificationEmail(&user, verificationCode)
+	e = s.emailVerifier.SendVerificationEmail(&user, userEmail, verificationCode)
 	if e != nil {
 		return e
 	}

--- a/server/resource_server/service/service_test.go
+++ b/server/resource_server/service/service_test.go
@@ -59,7 +59,6 @@ func (m *mockRepository) LoginPreCheckUser(req dto.LoginPrecheckDTO) (string, st
 
 func (m *mockRepository) LoginUser(req dto.LoginUserDTO) (models.User, error) {
 	return models.User{
-		Email:     "test@gcitizen.com",
 		Username:  "test_user",
 		FirstName: "Test",
 		LastName:  "User",
@@ -71,7 +70,6 @@ func (m *mockRepository) LoginUser(req dto.LoginUserDTO) (models.User, error) {
 func (m *mockRepository) ProfileUser(userID uint) (models.User, []models.UserMetadata, error) {
 	if userID == 1 {
 		return models.User{
-				Email:     "test@gcitizen.com",
 				Username:  "test_user",
 				FirstName: "Test",
 				LastName:  "User",
@@ -198,7 +196,6 @@ func TestRegisterUser(t *testing.T) {
 
 	// Create a new mock request
 	req := dto.RegisterUserDTO{
-		Email:       "test@gcitizen.com",
 		Username:    "test_user",
 		FirstName:   "Test",
 		LastName:    "User",
@@ -280,7 +277,7 @@ func TestProfileUser(t *testing.T) {
 
 	// Use assert to check if the error is nil
 	assert.Nil(t, err)
-	assert.Equal(t, userDetails.Email, "test@gcitizen.com")
+	assert.Equal(t, userDetails.Username, "test_user")
 }
 
 func TestUpdateDisplayName(t *testing.T) {
@@ -380,7 +377,7 @@ func TestVerifyEmail_UserDoesNotExist(t *testing.T) {
 	emailVerifier := &verification.EmailVerifier{}
 
 	currService := service.NewService(mockRepo, emailVerifier)
-	e := currService.VerifyEmail(userId)
+	e := currService.VerifyEmail(userId, userEmail)
 
 	assert.NotNil(t, e)
 }
@@ -391,7 +388,6 @@ func TestVerifyEmail_UserExists_EmailFailedToBeSent(t *testing.T) {
 			return models.User{
 				ID:               userId,
 				Username:         username,
-				Email:            userEmail,
 				VerificationCode: "",
 			}, nil
 		},
@@ -410,7 +406,7 @@ func TestVerifyEmail_UserExists_EmailFailedToBeSent(t *testing.T) {
 	)
 	currService := service.NewService(mockRepo, emailVerifier)
 
-	e := currService.VerifyEmail(userId)
+	e := currService.VerifyEmail(userId, userEmail)
 
 	assert.NotNil(t, e)
 }
@@ -421,7 +417,6 @@ func TestVerifyEmail_UserExists_EmailSent_VerificationDataNotSaved(t *testing.T)
 			return models.User{
 				ID:               userId,
 				Username:         username,
-				Email:            userEmail,
 				VerificationCode: "",
 			}, nil
 		},
@@ -438,7 +433,7 @@ func TestVerifyEmail_UserExists_EmailSent_VerificationDataNotSaved(t *testing.T)
 	)
 	currService := service.NewService(mockRepo, emailVerifier)
 
-	e := currService.VerifyEmail(userId)
+	e := currService.VerifyEmail(userId, userEmail)
 
 	assert.NotNil(t, e)
 }
@@ -449,7 +444,6 @@ func TestVerifyEmail_Success(t *testing.T) {
 			return models.User{
 				ID:               userId,
 				Username:         username,
-				Email:            userEmail,
 				VerificationCode: "",
 			}, nil
 		},
@@ -466,7 +460,7 @@ func TestVerifyEmail_Success(t *testing.T) {
 	)
 	currService := service.NewService(mockRepo, emailVerifier)
 
-	e := currService.VerifyEmail(userId)
+	e := currService.VerifyEmail(userId, userEmail)
 
 	assert.Nil(t, e)
 }


### PR DESCRIPTION
## PR overview

I have removed email from the registration form as well as from the database.
Instead of requiring email at the registration stage, we will now require it when the user initiates the verification process (in the current flow this happens when user clicks the "Verify Email" button).

To implement this, I have added a new html page "input-your-email.html" which contains a form field to enter the email address and a "Get Code" button. It shows up after a user clicks the "Verify Email" button.
After clicking the "Get Code" button, the user is directed to the "input-verification-code.html" page, where they are asked to enter the verification code sent to the provided email address.

A new endpoint "/input-your-email-page" was implemented, which returns "input-your-email.html".
Also I renamed "/verify-email-page" -> "/input-verification-code-page".

Removed email field from "profile.html" and "register.html".

Removed email column from the "users" table.


## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the newly registered credentials from Section 1 succeeds
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
