### PR TITLE
refactor: authorization handler to be more testable

### DIFF
--- a/server/cmd/app/main.go
+++ b/server/cmd/app/main.go
@@ -148,7 +148,12 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 
 	getPwd()
 
-	authHandler := handlers.NewAuthenticationHandler(
+	authenticationHandler := handlers.NewAuthenticationHandler(
+		oauthService,
+		utils.ParseHTML,
+	)
+
+	authorizationHandler := handlers.NewAuthorizationHandler(
 		oauthService,
 		utils.ParseHTML,
 	)
@@ -179,13 +184,13 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 
 			// Authorization Server endpoints
 			case path == "/login":
-				authHandler.Login(w, r)
+				authenticationHandler.Login(w, r)
 			case path == "/authorize":
-				handlers.Authorize(w, r)
+				authorizationHandler.Authorize(w, r)
 			case path == "/error":
-				handlers.Error(w, r)
+				authorizationHandler.Error(w, r)
 			case path == "/api/oauth":
-				handlers.OAuthToken(w, r)
+				authorizationHandler.OAuthToken(w, r)
 			case path == "/api/user":
 				handlers.UserInfo(w, r)
 			case strings.HasPrefix(path, "/assets-v1"):

--- a/server/handlers/authorization.go
+++ b/server/handlers/authorization.go
@@ -1,14 +1,9 @@
 package handlers
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"globe-and-citizen/layer8/server/constants"
 	svc "globe-and-citizen/layer8/server/internals/service"
-	"globe-and-citizen/layer8/server/models"
-	"html/template"
+	"globe-and-citizen/layer8/server/utils"
 	"log"
 	"net/http"
 	"net/url"
@@ -18,8 +13,196 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func Authorize(w http.ResponseWriter, r *http.Request) {
-	service := r.Context().Value("Oauthservice").(*svc.Service)
+type AuthorizationHandler interface {
+	Authorize(w http.ResponseWriter, r *http.Request)
+	OAuthToken(w http.ResponseWriter, r *http.Request)
+	Error(w http.ResponseWriter, r *http.Request)
+}
+
+type authorizationHandlerImpl struct {
+	service   svc.ServiceInterface
+	parseHTML func(w http.ResponseWriter, htmlFile string, params map[string]interface{})
+}
+
+func NewAuthorizationHandler(
+	service svc.ServiceInterface,
+	htmlParserFunc func(w http.ResponseWriter, htmlFile string, params map[string]interface{}),
+) AuthorizationHandler {
+	return &authorizationHandlerImpl{
+		service:   service,
+		parseHTML: htmlParserFunc,
+	}
+}
+
+func (a *authorizationHandlerImpl) Authorize(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		a.getAuthorizeHandler(w, r)
+	case "POST":
+		a.postAuthorizeHandler(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *authorizationHandlerImpl) getAuthorizeHandler(w http.ResponseWriter, r *http.Request) {
+	var (
+		clientID          = r.URL.Query().Get("client_id")
+		scopes            = r.URL.Query().Get("scope")
+		redirectURI       = r.URL.Query().Get("redirect_uri")
+		scopeDescriptions = []string{}
+		next              string
+	)
+
+	// use the default scope if none is provided
+	if scopes == "" {
+		scopes = constants.READ_USER_SCOPE
+	}
+
+	// add the scope descriptions
+	for _, scope := range strings.Split(scopes, ",") {
+		scopeDescriptions = append(scopeDescriptions, constants.ScopeDescriptions[scope])
+	}
+
+	// get the client
+	client, err := a.service.GetClient(clientID)
+	if err != nil {
+		log.Println(err)
+		// redirect to the redirect_uri with error
+		http.Redirect(w, r, "/error?opt=invalid_client", http.StatusSeeOther)
+		return
+	}
+
+	// generate the next url
+	uri, err := url.Parse("/authorize")
+	if err != nil {
+		log.Println(err)
+		http.Redirect(w, r, "/error?opt=server_error", http.StatusSeeOther)
+		return
+	}
+
+	uri.RawQuery = url.Values{
+		"client_id": {clientID},
+		"scope":     {scopes},
+	}.Encode()
+
+	next = uri.String()
+
+	// check that the user is logged in
+	token, err := r.Cookie("token")
+	if token == nil || err != nil {
+		http.Redirect(w, r, "/login?next="+next, http.StatusSeeOther)
+		return
+	}
+
+	user, err := a.service.GetUserByToken(token.Value)
+	if err != nil || user == nil {
+		http.Redirect(w, r, "/login?next="+next, http.StatusSeeOther)
+		return
+	}
+
+	// check that the redirect_uri is valid match the client's redirect_uri
+	if redirectURI != "" && client.RedirectURI != redirectURI {
+		http.Redirect(w, r, "/error?opt=redirect_uri_mismatch", http.StatusSeeOther)
+		return
+	}
+
+	a.parseHTML(w, "assets-v1/templates/src/pages/oauth_portal/authorize.html", map[string]interface{}{
+		"ClientName": client.Name,
+		"Scopes":     scopeDescriptions,
+		"Next":       next,
+	})
+}
+
+func (a *authorizationHandlerImpl) postAuthorizeHandler(w http.ResponseWriter, r *http.Request) {
+	var (
+		clientID        = r.URL.Query().Get("client_id")
+		scopes          = r.URL.Query().Get("scope")
+		returnResult, _ = strconv.ParseBool(r.URL.Query().Get("return_result"))
+	)
+
+	decision := r.FormValue("decision")
+	if decision != "allow" {
+		log.Println("User denied access")
+		utils.MapResponse(
+			returnResult, w,
+			&utils.JSONResponseInput{
+				StatusCode: http.StatusOK,
+				Data:       `{"redr": "/error?opt=access_denied"}`,
+			},
+			&utils.RedirectResponseInput{
+				StatusCode: http.StatusSeeOther,
+				Location:   "/error?opt=access_denied",
+			},
+		)
+
+		return
+	}
+
+	// get the client
+	client, err := a.service.GetClient(clientID)
+	if err != nil {
+		log.Println(err)
+		utils.MapResponse(
+			returnResult, w,
+			&utils.JSONResponseInput{
+				StatusCode: http.StatusOK,
+				Data:       `{"redr": "/error?opt=invalid_client"}`,
+			},
+			&utils.RedirectResponseInput{
+				StatusCode: http.StatusSeeOther,
+				Location:   "/error?opt=invalid_client",
+			},
+		)
+		return
+	}
+
+	token, err := r.Cookie("token")
+	if err != nil || token == nil {
+		utils.MapResponse(
+			returnResult, w,
+			&utils.JSONResponseInput{
+				StatusCode: http.StatusOK,
+				Data:       `{"redr": "/login?next=` + r.URL.String() + `"}`,
+			},
+			&utils.RedirectResponseInput{
+				StatusCode: http.StatusSeeOther,
+				Location:   "/login?next=" + r.URL.String(),
+			},
+		)
+	}
+
+	user, err := a.service.GetUserByToken(token.Value)
+	if err != nil || user == nil {
+		utils.MapResponse(
+			returnResult, w,
+			&utils.JSONResponseInput{
+				StatusCode: http.StatusOK,
+				Data:       `{"redr": "/login?next=` + r.URL.String() + `"}`,
+			},
+			&utils.RedirectResponseInput{
+				StatusCode: http.StatusSeeOther,
+				Location:   "/login?next=" + r.URL.String(),
+			},
+		)
+
+		return
+	}
+
+	if scopes == "" {
+		scopes = constants.READ_USER_SCOPE
+	}
+
+	if r.FormValue("share_display_name") == "true" {
+		scopes += "," + constants.READ_USER_DISPLAY_NAME_SCOPE
+	}
+	if r.FormValue("share_country") == "true" {
+		scopes += "," + constants.READ_USER_COUNTRY_SCOPE
+	}
+
+	if r.FormValue("share_top_five_metadata") == "true" {
+		scopes += "," + constants.READ_USER_TOP_FIVE_METADATA
+	}
 
 	var headerMap = make(map[string]string)
 	headerMap["Sec-Ch-Ua-Platform"] = r.Header.Get("Sec-Ch-Ua-Platform")
@@ -28,295 +211,141 @@ func Authorize(w http.ResponseWriter, r *http.Request) {
 	headerMap["Sec-Ch-Ua"] = r.Header.Get("Sec-Ch-Ua")
 	headerMap["User-Agent"] = r.Header.Get("User-Agent")
 
+	authURL, err := a.service.GenerateAuthorizationURL(&oauth2.Config{
+		ClientID:    client.ID,
+		RedirectURL: client.RedirectURI,
+		Scopes:      strings.Split(scopes, ","),
+	}, int64(user.ID), headerMap)
+	if err != nil {
+		utils.MapResponse(
+			returnResult, w,
+			&utils.JSONResponseInput{
+				StatusCode: http.StatusOK,
+				Data:       `{"redr": "/error?opt=server_error"}`,
+			},
+			&utils.RedirectResponseInput{
+				StatusCode: http.StatusSeeOther,
+				Location:   "/error?opt=server_error",
+			},
+		)
+
+		return
+	}
+
+	utils.MapResponse(
+		returnResult, w,
+		&utils.JSONResponseInput{
+			StatusCode: http.StatusOK,
+			Data:       `{"redr": "` + authURL.String() + `"}`,
+		},
+		&utils.RedirectResponseInput{
+			StatusCode: http.StatusSeeOther,
+			Location:   authURL.String(),
+		},
+	)
+}
+
+func (a *authorizationHandlerImpl) OAuthToken(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "POST":
+		a.postOAauthToken(w, r)
+	default:
+		utils.WriteJSONResponse(
+			w,
+			http.StatusMethodNotAllowed,
+			`{"error": "method not allowed"}`,
+		)
+
+		return
+	}
+}
+
+func (a *authorizationHandlerImpl) postOAauthToken(w http.ResponseWriter, r *http.Request) {
+	var (
+		code        = r.FormValue("code")
+		redirectURI = r.FormValue("redirect_uri")
+	)
+
+	clientID, clientSecret, err := utils.GetClientIDAndSecretFromAuthHeader(r.Header.Get("Authorization"))
+	if err != nil {
+		utils.WriteJSONResponse(
+			w,
+			http.StatusUnauthorized,
+			`{"error": "`+err.Error()+`"}`,
+		)
+
+		return
+	}
+
+	// get the client
+	client, err := a.service.GetClient(clientID)
+	if err != nil {
+		utils.WriteJSONResponse(
+			w,
+			http.StatusUnauthorized,
+			`{"error": "invalid client"}`,
+		)
+		return
+	}
+
+	if client.Secret != clientSecret {
+		utils.WriteJSONResponse(
+			w,
+			http.StatusUnauthorized,
+			`{"error": "invalid client secret"}`,
+		)
+		return
+	}
+
+	token, err := a.service.ExchangeCodeForToken(&oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURI,
+	}, code)
+	if err != nil {
+		utils.WriteJSONResponse(
+			w,
+			http.StatusInternalServerError,
+			`{"error": "`+err.Error()+`"}`,
+		)
+
+		return
+	}
+
+	utils.WriteJSONResponse(
+		w,
+		http.StatusOK,
+		token,
+	)
+}
+
+func (a *authorizationHandlerImpl) Error(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
-		var (
-			clientID          = r.URL.Query().Get("client_id")
-			scopes            = r.URL.Query().Get("scope")
-			redirectURI       = r.URL.Query().Get("redirect_uri")
-			scopeDescriptions = []string{}
-			next              string
-		)
-		// use the default scope if none is provided
-		if scopes == "" {
-			scopes = constants.READ_USER_SCOPE
-		}
-		// add the scope descriptions
-		for _, scope := range strings.Split(scopes, ",") {
-			scopeDescriptions = append(scopeDescriptions, constants.ScopeDescriptions[scope])
-		}
-		// get the client
-		client, err := service.GetClient(clientID)
-		if err != nil {
-			log.Println(err)
-			// redirect to the redirect_uri with error
-			http.Redirect(w, r, "/error?opt=invalid_client", http.StatusSeeOther)
-			return
-		}
-		// generate the next url
-		uri, err := url.Parse("/authorize")
-		if err != nil {
-			log.Println(err)
-			http.Redirect(w, r, "/error?opt=server_error", http.StatusSeeOther)
-			return
-		}
-		q := uri.Query()
-		q.Set("client_id", clientID)
-		q.Set("scope", scopes)
-		uri.RawQuery = q.Encode()
-		next = uri.String()
-
-		// check that the user is logged in
-		token, err := r.Cookie("token")
-		if token != nil && err == nil {
-			user, err := service.GetUserByToken(token.Value)
-			if err != nil || user == nil {
-				http.Redirect(w, r, "/login?next="+next, http.StatusSeeOther)
-				return
-			}
-		} else {
-			http.Redirect(w, r, "/login?next="+next, http.StatusSeeOther)
-
-			return
-		}
-
-		// check that the redirect_uri is valid match the client's redirect_uri
-		if redirectURI != "" && client.RedirectURI != redirectURI {
-			http.Redirect(w, r, "/error?opt=redirect_uri_mismatch", http.StatusSeeOther)
-			return
-		}
-		// load the authorize page
-		t, err := template.ParseFiles("assets-v1/templates/src/pages/oauth_portal/authorize.html")
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		t.Execute(w, map[string]interface{}{
-			"ClientName": client.Name,
-			"Scopes":     scopeDescriptions,
-			"Next":       next,
-		})
-		return
-	case "POST":
-		var (
-			clientID        = r.URL.Query().Get("client_id")
-			scopes          = r.URL.Query().Get("scope")
-			returnResult, _ = strconv.ParseBool(r.URL.Query().Get("return_result"))
-		)
-		// get authorization decision
-		decision := r.FormValue("decision")
-		if decision != "allow" {
-			log.Println("User denied access")
-			if returnResult {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"redr": "/error?opt=access_denied"}`))
-				return
-			}
-			http.Redirect(w, r, "/error?opt=access_denied", http.StatusSeeOther)
-			return
-		}
-		// use the default scope if none is provided
-		if scopes == "" {
-			scopes = constants.READ_USER_SCOPE
-		}
-		// get the client
-		client, err := service.GetClient(clientID)
-		if err != nil {
-			log.Println(err)
-			if returnResult {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"redr": "/error?opt=invalid_client"}`))
-				return
-			}
-			http.Redirect(w, r, "/error?opt=invalid_client", http.StatusSeeOther)
-			return
-		}
-		// get user
-		var user *models.User
-		token, err := r.Cookie("token") // Ravi you may need to renag....
-		if token != nil && err == nil {
-			user, err = service.GetUserByToken(token.Value)
-			if err != nil || user == nil {
-				if returnResult {
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(`{"redr": "/login?next=` + r.URL.String() + `"}`))
-					return
-				}
-				http.Redirect(w, r, "/login?next="+r.URL.String(), http.StatusSeeOther)
-				return
-			}
-		} else {
-			if returnResult {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"redr": "/login?next=` + r.URL.String() + `"}`))
-				return
-			}
-			http.Redirect(w, r, "/login?next="+r.URL.String(), http.StatusSeeOther)
-			return
-		}
-		// fmt.Println("scopes before user decision: ", scopes)
-		if r.FormValue("share_display_name") == "true" {
-			scopes += "," + constants.READ_USER_DISPLAY_NAME_SCOPE
-		}
-		if r.FormValue("share_country") == "true" {
-			scopes += "," + constants.READ_USER_COUNTRY_SCOPE
-		}
-
-		if r.FormValue("share_top_five_metadata") == "true" {
-			scopes += "," + constants.READ_USER_TOP_FIVE_METADATA
-		}
-
-		// fmt.Println("scopes after user decision: ", scopes)
-		// generate authorization url
-		authURL, err := service.GenerateAuthorizationURL(&oauth2.Config{
-			ClientID:    client.ID,
-			RedirectURL: client.RedirectURI,
-			Scopes:      strings.Split(scopes, ","),
-		}, int64(user.ID), headerMap)
-		if err != nil {
-			log.Println("Server error: ", err)
-			if returnResult {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"redr": "/error?opt=server_error"}`))
-				return
-			}
-			http.Redirect(w, r, "/error?opt=server_error", http.StatusSeeOther)
-			return
-		}
-		// redirect to the authorization url
-		if returnResult {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"redr": "` + authURL.String() + `"}`))
-			fmt.Println("Normal exit...")
-			return
-		}
-		http.Redirect(w, r, authURL.String(), http.StatusSeeOther)
-		return
+		a.getError(w, r)
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 }
 
-func OAuthToken(w http.ResponseWriter, r *http.Request) {
-	service := r.Context().Value("Oauthservice").(*svc.Service)
-
-	// exchange code for token
-	switch r.Method {
-	case "POST":
-		var (
-			code        = r.FormValue("code")
-			redirectURI = r.FormValue("redirect_uri")
-		)
-
-		// decode the basic auth header
-		fromBasicAuth := func(t string) (string, string, error) {
-			t = strings.TrimPrefix(t, "Basic ")
-			b, err := base64.StdEncoding.DecodeString(t)
-			if err != nil {
-				return "", "", err
-			}
-			// first remove the "Basic " prefix
-			s := strings.SplitN(string(b), ":", 2)
-			if len(s) != 2 {
-				return "", "", errors.New("invalid basic auth header")
-			}
-			return s[0], s[1], nil
+func (a *authorizationHandlerImpl) getError(w http.ResponseWriter, r *http.Request) {
+	var (
+		opt    = r.URL.Query().Get("opt")
+		opts   = []string{}
+		errors = map[string]string{
+			"invalid_client":        "The client is invalid.",
+			"access_denied":         "The user denied the request.",
+			"server_error":          "An error occurred on the server.",
+			"redirect_uri_mismatch": "The redirect uri does not match the client's redirect uri.",
 		}
-		clientID, clientSecret, err := fromBasicAuth(r.Header.Get("Authorization"))
-		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error": "` + err.Error() + `"}`))
-			return
-		}
-
-		// get the client
-		client, err := service.GetClient(clientID)
-		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error": "invalid client"}`))
-			return
-		}
-		// check that the client secret is correct
-		if client.Secret != clientSecret {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error": "invalid client secret"}`))
-			return
-		}
-		// exchange code for token
-		token, err := service.ExchangeCodeForToken(&oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			RedirectURL:  redirectURI,
-		}, code)
-		if err != nil {
-			res := map[string]string{"error": err.Error()}
-			resJSON, _ := json.Marshal(res)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write(resJSON)
-			return
-		}
-		// return token
-		bToken, err := json.Marshal(token)
-		if err != nil {
-			res := map[string]string{"error": err.Error()}
-			resJSON, _ := json.Marshal(res)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write(resJSON)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(bToken)
-		return
-	default:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		w.Write([]byte(`{"error": "method not allowed"}`))
-		return
+	)
+	// add the error to the list of errors
+	for _, v := range strings.Split(opt, ",") {
+		opts = append(opts, errors[v])
 	}
-}
 
-func Error(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "GET":
-		var (
-			opt    = r.URL.Query().Get("opt")
-			opts   = []string{}
-			errors = map[string]string{
-				"invalid_client":        "The client is invalid.",
-				"access_denied":         "The user denied the request.",
-				"server_error":          "An error occurred on the server.",
-				"redirect_uri_mismatch": "The redirect uri does not match the client's redirect uri.",
-			}
-		)
-		// add the error to the list of errors
-		for _, v := range strings.Split(opt, ",") {
-			opts = append(opts, errors[v])
-		}
-		// load the error page
-		t, err := template.ParseFiles("assets-v1/templates/src/pages/oauth_portal/error.html")
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		t.Execute(w, map[string]interface{}{
-			"Errors": opts,
-		})
-		return
-	default:
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
+	a.parseHTML(w, "assets-v1/templates/src/pages/oauth_portal/error.html", map[string]interface{}{
+		"Errors": opts,
+	})
 }

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -2,7 +2,12 @@ package utils
 
 import (
 	"crypto/sha1"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
 
 	"github.com/xdg-go/pbkdf2"
 )
@@ -10,4 +15,51 @@ import (
 func SaltAndHashPassword(password string, salt string) string {
 	dk := pbkdf2.Key([]byte(password), []byte(salt), 4096, 32, sha1.New)
 	return hex.EncodeToString(dk[:])
+}
+
+func WriteJSONResponse(
+	w http.ResponseWriter,
+	status int,
+	data interface{},
+) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}
+
+type JSONResponseInput struct {
+	StatusCode int
+	Data       interface{}
+}
+
+type RedirectResponseInput struct {
+	StatusCode int
+	Location   string
+}
+
+func MapResponse(
+	isJson bool,
+	w http.ResponseWriter,
+	j *JSONResponseInput,
+	red *RedirectResponseInput,
+) {
+	if isJson {
+		WriteJSONResponse(w, j.StatusCode, j.Data)
+	} else {
+		http.Redirect(w, &http.Request{}, red.Location, red.StatusCode)
+	}
+}
+
+func GetClientIDAndSecretFromAuthHeader(t string) (string, string, error) {
+	t = strings.TrimPrefix(t, "Basic ")
+	b, err := base64.StdEncoding.DecodeString(t)
+	if err != nil {
+		return "", "", err
+	}
+	// first remove the "Basic " prefix
+	s := strings.SplitN(string(b), ":", 2)
+	if len(s) != 2 {
+		return "", "", errors.New("invalid basic auth header")
+	}
+	return s[0], s[1], nil
 }


### PR DESCRIPTION
## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [ ] http://localhost:5001/ home page loads
- [ ] "LoginAsUser" button takes you to the user login page
- [ ] Log in using "tester" and "12341234" should succeed
- [ ] Updating the display name should work
- [ ] Log out and Register a new user and try to log in with that new user
- [ ] "LoginAsClient" button takes you to the client login page
- [ ] Log in using "layer8" and "12341234" should work
- [ ] You will be able to see your UID and Secret in profile
- [ ] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [ ] Log in with 'tester' / '1234'
- [ ] Log in anonymously with Layer8
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
- [ ] Clicking "Logout" takes you to the login screen
- [ ] Clicking "Register" takes you to the registration page
- [ ] Registering with a username, password, and profile image is successful
- [ ] Logging in with the new username / password succeeds
- [ ] Logging in with Layer8 opens the pop-up
- [ ] Logging in with the newly registered credentials from Section 1 succeeds
- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
- [ ] Clicking "Logout" takes you to the login page
- [ ] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [ ] This time, DO NOT share "display name" or "country"
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [ ] Main page loads
- [ ] Upload of image works
- [ ] Reload leads to instant reload (demonstrating proper caching)
- [ ] Clicking the newly loaded image shows it in a lightbox
