### PR TITLE
Added error handling to frontend

### DIFF
--- a/server/assets-v1/templates/src/pages/client_portal/register.html
+++ b/server/assets-v1/templates/src/pages/client_portal/register.html
@@ -177,7 +177,7 @@
             showToastMessage("Please enter all fields!", "error")
             return;
           }
-          await window.fetch("[[ .ProxyURL ]]/api/v1/register-client", {
+          const resp = await window.fetch("[[ .ProxyURL ]]/api/v1/register-client", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -190,8 +190,15 @@
               password: password.value,
             }),
           });
-          showToastMessage("Registration successful!", "success")
-          window.location.href = "[[ .ProxyURL ]]/client-login-page";
+          const registerResponseBody = await resp.json();
+          if (registerResponseBody.message === "OK!") {
+            showToastMessage(registerResponseBody.message, "success");
+            window.location.href = "[[ .ProxyURL ]]/client-login-page";
+          } else if (registerResponseBody.message) {
+            showToastMessage(registerResponseBody.message, "error");
+          } else {
+            showToastMessage("Something went wrong!", "error");
+          }
         } catch (error) {
           console.error(error);
           showToastMessage("Registration failed!", "error")


### PR DESCRIPTION
## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [ ] Log in with 'tester' / '1234'
- [ ] Log in anonymously with Layer8
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
- [ ] Clicking "Logout" takes you to the login screen
- [ ] Clicking "Register" takes you to the registration page
- [ ] Registering with a username, password, and profile image is successful
- [ ] Logging in with the new username / password succeeds
- [ ] Logging in with Layer8 opens the pop-up
- [ ] Logging in with the newly registered credentials from Section 1 succeeds
- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3
- [ ] Clicking "Logout" takes you to the login page
- [ ] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [ ] This time, DO NOT share "display name" or "country"
- [ ] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [ ] Main page loads
- [ ] Upload of image works
- [ ] Reload leads to instant reload (demonstrating proper caching)
- [ ] Clicking the newly loaded image shows it in a lightbox


Certainly! Here's a well-structured pull request description for the issue:

---

### Fix: Prevent Multiple Users from Registering with the Same Username (#42)

**Issue**: Multiple users were able to register as a client with the same username, leading to potential conflicts and security risks. This was reported in issue #42.

**Solution**:
- Added error handling to provide a clear message when a user attempts to register with an already taken username.

**Related Issues**:
- Closes #42 