### PR TITLE
fixed json decoding

### DIFF
--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-playground/validator/v10"
-	"io"
 	"net/http"
 	"os"
 	"time"
@@ -63,8 +61,7 @@ func ServeFileHandler(w http.ResponseWriter, r *http.Request, filePath string) {
 func LoginClientHandler(w http.ResponseWriter, r *http.Request) {
 	newService := r.Context().Value("service").(interfaces.IService)
 
-	var request dto.LoginClientDTO
-	err := decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.LoginClientDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -106,8 +103,7 @@ func ClientProfileHandler(w http.ResponseWriter, r *http.Request) {
 func RegisterUserHandler(w http.ResponseWriter, r *http.Request) {
 	newService := r.Context().Value("service").(interfaces.IService)
 
-	var request dto.RegisterUserDTO
-	err := decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.RegisterUserDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -128,8 +124,7 @@ func RegisterUserHandler(w http.ResponseWriter, r *http.Request) {
 func RegisterClientHandler(w http.ResponseWriter, r *http.Request) {
 	newService := r.Context().Value("service").(interfaces.IService)
 
-	var request dto.RegisterClientDTO
-	err := decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.RegisterClientDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -151,8 +146,7 @@ func RegisterClientHandler(w http.ResponseWriter, r *http.Request) {
 func LoginPrecheckHandler(w http.ResponseWriter, r *http.Request) {
 	newService := r.Context().Value("service").(interfaces.IService)
 
-	var request dto.LoginPrecheckDTO
-	err := decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.LoginPrecheckDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -172,8 +166,7 @@ func LoginPrecheckHandler(w http.ResponseWriter, r *http.Request) {
 func LoginUserHandler(w http.ResponseWriter, r *http.Request) {
 	newService := r.Context().Value("service").(interfaces.IService)
 
-	var request dto.LoginUserDTO
-	err := decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.LoginUserDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -238,8 +231,7 @@ func VerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var request dto.VerifyEmailDTO
-	err = decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.VerifyEmailDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -267,8 +259,7 @@ func CheckEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var request dto.CheckEmailVerificationCodeDTO
-	err = decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.CheckEmailVerificationCodeDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -312,8 +303,7 @@ func UpdateDisplayNameHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var request dto.UpdateDisplayNameDTO
-	err = decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.UpdateDisplayNameDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -390,8 +380,7 @@ func GetUsageStats(w http.ResponseWriter, r *http.Request) {
 func CheckBackendURI(w http.ResponseWriter, r *http.Request) {
 	newService := r.Context().Value("service").(interfaces.IService)
 
-	var request dto.CheckBackendURIDTO
-	err := decodeJson(w, r.Body, &request)
+	request, err := utils.DecodeJsonFromRequest[dto.CheckBackendURIDTO](w, r.Body)
 	if err != nil {
 		return
 	}
@@ -406,26 +395,4 @@ func CheckBackendURI(w http.ResponseWriter, r *http.Request) {
 		utils.HandleError(w, http.StatusBadRequest, "Failed to check backend url", err)
 		return
 	}
-}
-
-func decodeJson(w http.ResponseWriter, byteBuffer io.ReadCloser, to any) error {
-	body, e := io.ReadAll(byteBuffer)
-	if e != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Error while reading request body", e)
-		return e
-	}
-
-	e = json.Unmarshal(body, to)
-	if e != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Request malformed: error while parsing json", e)
-		return e
-	}
-
-	e = validator.New().Struct(to)
-	if e != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Input json is invalid", e)
-		return e
-	}
-
-	return nil
 }

--- a/server/resource_server/utils/json.go
+++ b/server/resource_server/utils/json.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"encoding/json"
+	"github.com/go-playground/validator/v10"
+	"io"
+	"net/http"
+)
+
+func DecodeJsonFromRequest[T any](w http.ResponseWriter, byteBuffer io.ReadCloser) (T, error) {
+	var to T
+
+	body, e := io.ReadAll(byteBuffer)
+	if e != nil {
+		HandleError(w, http.StatusBadRequest, "Error while reading request body", e)
+		return to, e
+	}
+
+	e = json.Unmarshal(body, &to)
+	if e != nil {
+		HandleError(w, http.StatusBadRequest, "Request malformed: error while parsing json", e)
+		return to, e
+	}
+
+	e = validator.New().Struct(to)
+	if e != nil {
+		HandleError(w, http.StatusBadRequest, "Input json is invalid", e)
+		return to, e
+	}
+
+	return to, nil
+}


### PR DESCRIPTION
## Description

Replaced ```json.NewDecoder(r.Body).Decode(&req)``` with ```json.Unmarshal(body, to)```, because ```json.NewDecoder``` does not return any error when the request json is malformed (e.g. input contains some trailing data after the json).

## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the newly registered credentials from Section 1 succeeds
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
