### PR TITLE
fixed the returned status codes

### DIFF
--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -73,8 +73,12 @@ func LoginClientHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(tokenResp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get client profile", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -84,7 +88,7 @@ func ClientProfileHandler(w http.ResponseWriter, r *http.Request) {
 	tokenString = tokenString[7:]
 	clientClaims, err := utils.ValidateClientToken(tokenString)
 	if err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get user profile, invalid token", err)
+		utils.HandleError(w, http.StatusUnauthorized, "Authentication error: invalid token", err)
 		return
 	}
 
@@ -95,8 +99,12 @@ func ClientProfileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(profileResp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get user profile, error encoding response", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -116,8 +124,12 @@ func RegisterUserHandler(w http.ResponseWriter, r *http.Request) {
 
 	res := utils.BuildResponse(true, "OK!", "User registered successfully")
 	if err := json.NewEncoder(w).Encode(res); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to register user", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -137,8 +149,12 @@ func RegisterClientHandler(w http.ResponseWriter, r *http.Request) {
 
 	res := utils.BuildResponse(true, "OK!", "Client registered successfully")
 	if err := json.NewEncoder(w).Encode(res); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to register client", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -158,8 +174,12 @@ func LoginPrecheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(loginPrecheckResp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get client profile", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -178,8 +198,12 @@ func LoginUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(tokenResp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get client profile", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -189,7 +213,7 @@ func ProfileHandler(w http.ResponseWriter, r *http.Request) {
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
 	userID, err := utils.ValidateToken(tokenString)
 	if err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get user profile", err)
+		utils.HandleError(w, http.StatusUnauthorized, "Authentication error: invalid token", err)
 		return
 	}
 
@@ -200,8 +224,12 @@ func ProfileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(profileResp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get user profile", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -216,8 +244,12 @@ func GetClientData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(clientModel); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get client profile", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -227,7 +259,7 @@ func VerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
 	userID, err := utils.ValidateToken(tokenString)
 	if err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Request failed: invalid authorization token", err)
+		utils.HandleError(w, http.StatusUnauthorized, "Authentication error: invalid token", err)
 		return
 	}
 
@@ -255,7 +287,7 @@ func CheckEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
 	userID, err := utils.ValidateToken(tokenString)
 	if err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to verify user's token", err)
+		utils.HandleError(w, http.StatusUnauthorized, "Authentication error: invalid token", err)
 		return
 	}
 
@@ -305,7 +337,7 @@ func UpdateDisplayNameHandler(w http.ResponseWriter, r *http.Request) {
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
 	userID, err := utils.ValidateToken(tokenString)
 	if err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to update display name", err)
+		utils.HandleError(w, http.StatusUnauthorized, "Authentication error: invalid token", err)
 		return
 	}
 
@@ -322,8 +354,12 @@ func UpdateDisplayNameHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp := utils.BuildResponse(true, "OK!", "Display name updated successfully")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to update display name", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -378,8 +414,12 @@ func GetUsageStats(w http.ResponseWriter, r *http.Request) {
 
 	resp := utils.BuildResponse(true, "OK!", finalResponse)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to get stats", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }
 
@@ -398,7 +438,11 @@ func CheckBackendURI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		utils.HandleError(w, http.StatusBadRequest, "Failed to check backend url", err)
-		return
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
 	}
 }


### PR DESCRIPTION
## Description

Fixed status codes returned by the resource server in failure cases.
Now we return 401 (Unauthorized) if authentication token is invalid and 500 (Internal error) if there happened any error non-related to the user's input, e.g. when encoding the server response into json.
Previously 400 (Bad request) was returned in all the cases.

## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the newly registered credentials from Section 1 succeeds
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
