### PR TITLE
added http method checks in resource server endpoints

### DIFF
--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -59,6 +59,10 @@ func ServeFileHandler(w http.ResponseWriter, r *http.Request, filePath string) {
 }
 
 func LoginClientHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 
 	request, err := utils.DecodeJsonFromRequest[dto.LoginClientDTO](w, r.Body)
@@ -83,6 +87,10 @@ func LoginClientHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func ClientProfileHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodGet) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 	tokenString := r.Header.Get("Authorization")
 	tokenString = tokenString[7:]
@@ -109,6 +117,10 @@ func ClientProfileHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func RegisterUserHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 
 	request, err := utils.DecodeJsonFromRequest[dto.RegisterUserDTO](w, r.Body)
@@ -134,6 +146,10 @@ func RegisterUserHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func RegisterClientHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 
 	request, err := utils.DecodeJsonFromRequest[dto.RegisterClientDTO](w, r.Body)
@@ -160,6 +176,10 @@ func RegisterClientHandler(w http.ResponseWriter, r *http.Request) {
 
 // LoginPrecheckHandler handles login precheck requests and get the salt of the user from the database using the username from the request URL
 func LoginPrecheckHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 
 	request, err := utils.DecodeJsonFromRequest[dto.LoginPrecheckDTO](w, r.Body)
@@ -184,6 +204,10 @@ func LoginPrecheckHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func LoginUserHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 
 	request, err := utils.DecodeJsonFromRequest[dto.LoginUserDTO](w, r.Body)
@@ -208,6 +232,10 @@ func LoginUserHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func ProfileHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodGet) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 	tokenString := r.Header.Get("Authorization")
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
@@ -234,6 +262,10 @@ func ProfileHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetClientData(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodGet) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 	clientName := r.Header.Get("Name")
 
@@ -254,6 +286,10 @@ func GetClientData(w http.ResponseWriter, r *http.Request) {
 }
 
 func VerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 	tokenString := r.Header.Get("Authorization")
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
@@ -282,6 +318,10 @@ func VerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func CheckEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	service := r.Context().Value("service").(interfaces.IService)
 	tokenString := r.Header.Get("Authorization")
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
@@ -329,6 +369,10 @@ func CheckEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
 }
 
 func UpdateDisplayNameHandler(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 	tokenString := r.Header.Get("Authorization")
 	tokenString = tokenString[7:] // Remove the "Bearer " prefix
@@ -361,6 +405,10 @@ func UpdateDisplayNameHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetUsageStats(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodGet) {
+		return
+	}
+
 	authToken := r.Header.Get("Authorization")
 	if authToken == "" {
 		utils.HandleError(w, http.StatusUnauthorized, "failed to show client usage statistics", errors.New("missing jwt token"))
@@ -421,6 +469,10 @@ func GetUsageStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func CheckBackendURI(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
 	newService := r.Context().Value("service").(interfaces.IService)
 
 	request, err := utils.DecodeJsonFromRequest[dto.CheckBackendURIDTO](w, r.Body)
@@ -442,4 +494,19 @@ func CheckBackendURI(w http.ResponseWriter, r *http.Request) {
 			err,
 		)
 	}
+}
+
+func validateHttpMethod(w http.ResponseWriter, actualMethod string, expectedMethod string) bool {
+	if actualMethod != expectedMethod {
+		errorMessage := fmt.Sprintf("Invalid http method. Expected %s", expectedMethod)
+		utils.HandleError(
+			w,
+			http.StatusMethodNotAllowed,
+			errorMessage,
+			fmt.Errorf(errorMessage),
+		)
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
## Description

Added checks of http request methods within the resource server controller.

## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the newly registered credentials from Section 1 succeeds
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
