### PR TITLE
added required field validation in dto

### DIFF
--- a/server/assets-v1/templates/src/pages/user_portal/login.html
+++ b/server/assets-v1/templates/src/pages/user_portal/login.html
@@ -124,9 +124,9 @@
               }),
             }
           );
-          const responseOne = await respOne.json();
+          const responseBody = await respOne.json();
 
-          if (responseOne.status === false) {
+          if (respOne.status !== 200) {
               showToastMessage("Failed to get client profile", "error");
               return;
           }
@@ -141,7 +141,7 @@
               body: JSON.stringify({
                 username: loginUsername.value,
                 password: loginPassword.value,
-                salt: responseOne.salt,
+                salt: responseBody.salt,
               }),
             }
           );

--- a/server/assets-v1/templates/src/pages/user_portal/login.html
+++ b/server/assets-v1/templates/src/pages/user_portal/login.html
@@ -125,6 +125,12 @@
             }
           );
           const responseOne = await respOne.json();
+
+          if (responseOne.status === false) {
+              showToastMessage("Failed to get client profile", "error");
+              return;
+          }
+
           const respTwo = await window.fetch(
             "[[ .ProxyURL ]]/api/v1/login-user",
             {

--- a/server/resource_server/controller/controller_test.go
+++ b/server/resource_server/controller/controller_test.go
@@ -227,6 +227,37 @@ func TestRegisterUserHandler_RequestJsonIsMalformed(t *testing.T) {
 	assert.NotNil(t, response.Error)
 }
 
+func TestRegisterUserHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	requestBody := []byte(`{
+		"email": "test@gcitizen.com",
+		"first_name": "Test",
+		"last_name": "User",
+		"display_name": "user",
+		"country": "Unknown",
+		"password": "12345"
+	}`)
+
+	req, err := http.NewRequest("POST", "/api/v1/register-user", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockService := &MockService{}
+	req = req.WithContext(context.WithValue(req.Context(), "service", mockService))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.RegisterUserHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
 func TestRegisterUserHandler_Success(t *testing.T) {
 	// Mock request body
 	requestBody := []byte(`{
@@ -324,6 +355,35 @@ func TestRegisterClientHandler_RequestJsonIsMalformed(t *testing.T) {
 	assert.NotNil(t, response.Error)
 }
 
+func TestRegisterClientHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	requestBody := []byte(`{
+		"name": "testclient", 
+		"redirect_uri": "https://gcitizen.com/callback",
+		"backend_uri": "https://backend.com",
+		"username": "test_user"
+	}`)
+
+	req, err := http.NewRequest("POST", "/api/v1/register-client", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockService := &MockService{}
+	req = req.WithContext(context.WithValue(req.Context(), "service", mockService))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.RegisterClientHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
 func TestRegisterClientHandler_Success(t *testing.T) {
 	// Mock request body
 	requestBody := []byte(`{
@@ -412,6 +472,30 @@ func TestLoginPrecheckHandler_RequestJsonIsMalformed(t *testing.T) {
 	assert.NotNil(t, response.Error)
 }
 
+func TestLoginPrecheckHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	requestBody := []byte(`{}`)
+
+	req, err := http.NewRequest("POST", "/api/v1/login-precheck", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockService := &MockService{}
+	req = req.WithContext(context.WithValue(req.Context(), "service", mockService))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.LoginPrecheckHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
 func TestLoginPrecheckHandler_Success(t *testing.T) {
 	// Mock request body
 	requestBody := []byte(`{"username": "test_user"}`)
@@ -494,6 +578,32 @@ func TestLoginUserHandler_RequestJsonIsMalformed(t *testing.T) {
 
 	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Request malformed: error while parsing json", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestLoginUserHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	requestBody := []byte(`{
+		"username": "test_user",
+		"password": "12345"
+	}`)
+	req, err := http.NewRequest("POST", "/api/v1/login-user", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockService := &MockService{}
+	req = req.WithContext(context.WithValue(req.Context(), "service", mockService))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.LoginUserHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
 
@@ -1242,6 +1352,31 @@ func TestUpdateDisplayNameHandler_RequestJsonIsMalformed(t *testing.T) {
 	assert.NotNil(t, response.Error)
 }
 
+func TestUpdateDisplayNameHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	requestBody := []byte(`{}`)
+	req, err := http.NewRequest("POST", "/api/v1/update-display-name", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+authenticationToken)
+
+	mockService := &MockService{}
+	req = req.WithContext(context.WithValue(req.Context(), "service", mockService))
+
+	rr := httptest.NewRecorder()
+
+	Ctl.UpdateDisplayNameHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
 func TestUpdateDisplayNameHandler_Success(t *testing.T) {
 	requestBody := []byte(`{"display_name": "test_user"}`)
 	req, err := http.NewRequest("POST", "/api/v1/update-display-name", bytes.NewBuffer(requestBody))
@@ -1310,6 +1445,27 @@ func TestLoginClientHandler_RequestJsonIsMalformed(t *testing.T) {
 	assert.NotNil(t, response.Error)
 }
 
+func TestLoginClientHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	loginReq := []byte(`{
+		"username": "testuser"
+	}`)
+
+	req := httptest.NewRequest("POST", "/api/v1/login-client", bytes.NewBuffer(loginReq))
+	req = setMockServiceInContext(req)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.LoginClientHandler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
 func TestLoginClientHandler_Success(t *testing.T) {
 	loginReq := []byte(`{
 		"username": "testuser",
@@ -1372,6 +1528,24 @@ func TestCheckBackendURIHandler_RequestJsonIsMalformed(t *testing.T) {
 
 	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Request malformed: error while parsing json", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestCheckBackendURIHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
+	reqBody := []byte(`{}`)
+	req := httptest.NewRequest("POST", "/api/v1/check-backend-uri", bytes.NewBuffer(reqBody))
+	req = setMockServiceInContext(req)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.CheckBackendURI(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBody(t, rr)
+
+	assert.False(t, response.Status)
+	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
 

--- a/server/resource_server/controller/controller_test.go
+++ b/server/resource_server/controller/controller_test.go
@@ -251,9 +251,9 @@ func TestRegisterUserHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
@@ -377,9 +377,9 @@ func TestRegisterClientHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
@@ -489,9 +489,9 @@ func TestLoginPrecheckHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) 
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
@@ -600,9 +600,9 @@ func TestLoginUserHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
@@ -1370,9 +1370,9 @@ func TestUpdateDisplayNameHandler_RequiredRequestJsonFieldsAreMissing(t *testing
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
@@ -1459,9 +1459,9 @@ func TestLoginClientHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }
@@ -1542,9 +1542,9 @@ func TestCheckBackendURIHandler_RequiredRequestJsonFieldsAreMissing(t *testing.T
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-	response := decodeResponseBody(t, rr)
+	response := decodeResponseBodyForErrorResponse(t, rr)
 
-	assert.False(t, response.Status)
+	assert.False(t, response.IsSuccess)
 	assert.Equal(t, "Input json is invalid", response.Message)
 	assert.NotNil(t, response.Error)
 }

--- a/server/resource_server/dto/dto.go
+++ b/server/resource_server/dto/dto.go
@@ -10,22 +10,22 @@ type RegisterUserDTO struct {
 }
 
 type LoginUserDTO struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Salt     string `json:"salt"`
+	Username string `json:"username" validate:"required"`
+	Password string `json:"password" validate:"required"`
+	Salt     string `json:"salt" validate:"required"`
 }
 
 type LoginClientDTO struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username" validate:"required"`
+	Password string `json:"password" validate:"required"`
 }
 
 type LoginPrecheckDTO struct {
-	Username string `json:"username"`
+	Username string `json:"username" validate:"required"`
 }
 
 type UpdateDisplayNameDTO struct {
-	DisplayName string `json:"display_name"`
+	DisplayName string `json:"display_name" validate:"required"`
 }
 
 type RegisterClientDTO struct {

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/go-playground/validator/v10"
 	"globe-and-citizen/layer8/server/resource_server/dto"
 	"globe-and-citizen/layer8/server/resource_server/emails/verification"
 	"globe-and-citizen/layer8/server/resource_server/emails/verification/zk"
@@ -42,10 +41,6 @@ func (s *service) RegisterUser(req dto.RegisterUserDTO) error {
 }
 
 func (s *service) RegisterClient(req dto.RegisterClientDTO) error {
-	if err := validator.New().Struct(req); err != nil {
-		return err
-	}
-
 	clientUUID := utils.GenerateUUID()
 	clientSecret := utils.GenerateSecret(utils.SecretSize)
 
@@ -99,9 +94,6 @@ func (s *service) GetClientDataByBackendURL(backendURL string) (models.ClientRes
 }
 
 func (s *service) LoginPreCheckUser(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error) {
-	if err := validator.New().Struct(req); err != nil {
-		return models.LoginPrecheckResponseOutput{}, err
-	}
 	username, salt, err := s.repository.LoginPreCheckUser(req)
 	if err != nil {
 		return models.LoginPrecheckResponseOutput{}, err
@@ -114,9 +106,6 @@ func (s *service) LoginPreCheckUser(req dto.LoginPrecheckDTO) (models.LoginPrech
 }
 
 func (s *service) LoginPreCheckClient(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error) {
-	if err := validator.New().Struct(req); err != nil {
-		return models.LoginPrecheckResponseOutput{}, err
-	}
 	username, salt, err := s.repository.LoginPreCheckClient(req)
 	if err != nil {
 		return models.LoginPrecheckResponseOutput{}, err
@@ -129,9 +118,6 @@ func (s *service) LoginPreCheckClient(req dto.LoginPrecheckDTO) (models.LoginPre
 }
 
 func (s *service) LoginUser(req dto.LoginUserDTO) (models.LoginUserResponseOutput, error) {
-	if err := validator.New().Struct(req); err != nil {
-		return models.LoginUserResponseOutput{}, err
-	}
 	user, err := s.repository.LoginUser(req)
 	if err != nil {
 		return models.LoginUserResponseOutput{}, err
@@ -144,9 +130,6 @@ func (s *service) LoginUser(req dto.LoginUserDTO) (models.LoginUserResponseOutpu
 }
 
 func (s *service) LoginClient(req dto.LoginClientDTO) (models.LoginUserResponseOutput, error) {
-	if err := validator.New().Struct(req); err != nil {
-		return models.LoginUserResponseOutput{}, err
-	}
 	client, err := s.repository.LoginClient(req)
 	if err != nil {
 		return models.LoginUserResponseOutput{}, err
@@ -251,9 +234,6 @@ func (s *service) SaveProofOfEmailVerification(userId uint, verificationCode str
 }
 
 func (s *service) UpdateDisplayName(userID uint, req dto.UpdateDisplayNameDTO) error {
-	if err := validator.New().Struct(req); err != nil {
-		return err
-	}
 	return s.repository.UpdateDisplayName(userID, req)
 }
 

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -30,10 +30,6 @@ func NewService(
 }
 
 func (s *service) RegisterUser(req dto.RegisterUserDTO) error {
-	if err := validator.New().Struct(req); err != nil {
-		return err
-	}
-
 	rmSalt := utils.GenerateRandomSalt(utils.SaltSize)
 	hashedAndSaltedPass := utils.SaltAndHashPassword(req.Password, rmSalt)
 


### PR DESCRIPTION
## Description

Added validation of required json fields in DTOs and implemented unit tests to assert that.
Updated login.html to process the error returned by "login-precheck" endpoint in case the requested user does not exist. Otherwise, if the precheck endpoint returns an error and the returned salt is null, the "login" endpoint would return the json validation error.

## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] http://localhost:5001/ home page loads
- [x] "LoginAsUser" button takes you to the user login page
- [x] Log in using "tester" and "12341234" should succeed
- [x] Updating the display name should work
- [x] Log out and Register a new user and try to log in with that new user
- [x] "LoginAsClient" button takes you to the client login page
- [x] Log in using "layer8" and "12341234" should work
- [x] You will be able to see your UID and Secret in profile
- [x] Log out and Register a new client and log in using that should work

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the newly registered credentials from Section 1 succeeds
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page
- [x] Log in with 'tester' / '1234', and then with the credentials from Section 1 succeeds
- [x] This time, DO NOT share "display name" or "country"
- [x] Clicking "Get Next Poem" loads different poem correctly x 3

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a lightbox
