### PR TITLE
Reverted changes to fix build issue

### DIFF
--- a/server/handlers/tunnel.go
+++ b/server/handlers/tunnel.go
@@ -107,7 +107,7 @@ func InitTunnel(w http.ResponseWriter, r *http.Request) {
 
 	// Convert resBodyTemp to []byte
 
-	// resBodyTempBytes := resBodyTemp.Bytes()
+	resBodyTempBytes := resBodyTemp.Bytes()
 
 	// Make a copy of the response body to send back to client
 	res.Body = io.NopCloser(bytes.NewBuffer(resBodyTemp.Bytes()))
@@ -119,8 +119,8 @@ func InitTunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// server_pubKeyECDH, err := utilities.B64ToJWK(string(resBodyTempBytes))
-	server_pubKeyECDH, err := utilities.B64ToJWK(res.Header.Get("server_pubKeyECDH"))
+	server_pubKeyECDH, err := utilities.B64ToJWK(string(resBodyTempBytes))
+	// server_pubKeyECDH, err := utilities.B64ToJWK(res.Header.Get("server_pubKeyECDH"))
 	if err != nil {
 		fmt.Println(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [ ] Created a new user on the Layer8 Portal

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [ ] Login as 'tester', '1234'
- [ ] Choose login with layer8 
- [ ] Logging in with the newly registered credentials from Section 1 succeeds in popup
- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [ ] Choose poems 1 - 3 works correctly 

### SECTION 3: IMSHARER (http://localhost:5174/)
- [ ] Uploads an image works
- [ ] Reload leads to instant reload (demonstrating proper caching)


