### PR TITLE
[ISSUE-165] Implemented SCRAM in User Login Flow

### DIFF
--- a/server/assets-v1/templates/src/pages/user_portal/login_v2.html
+++ b/server/assets-v1/templates/src/pages/user_portal/login_v2.html
@@ -97,9 +97,9 @@
         }
 
         const cNonceLength = 32;
-        const cNonceBytes = new Uint8Array(cNonceLength);
-        window.crypto.getRandomValues(cNonceBytes);
-        cNonce.value = btoa(String.fromCharCode(...cNonceBytes));
+        const cNonceUintArray = new Uint8Array(cNonceLength);
+        window.crypto.getRandomValues(cNonceUintArray);
+        cNonce.value = btoa(String.fromCharCode(...cNonceUintArray));
 
         const loginPrecheckResponse = await window.fetch(
           "[[ .ProxyURL ]]/api/v2/login-precheck",

--- a/server/assets-v1/templates/src/pages/user_portal/login_v2.html
+++ b/server/assets-v1/templates/src/pages/user_portal/login_v2.html
@@ -41,7 +41,7 @@
               v-model="loginPassword" type="password" placeholder="Password" />
           </div>
           <a class="text-sm text-[#414141] font-normal text-center block cursor-pointer"
-            href="/reset-password-page">Forgot your password?</a>
+            href="/v2/reset-password-page">Forgot your password?</a>
           <button class="w-full bg-[#4F80E1] rounded-lg text-center text-white py-4 mb-12" @click="loginUser">
             Login
           </button>

--- a/server/assets-v1/templates/src/pages/user_portal/login_v2.html
+++ b/server/assets-v1/templates/src/pages/user_portal/login_v2.html
@@ -115,7 +115,7 @@
           }
         );
         const loginPrecheckResponseBody = await loginPrecheckResponse.json();
-
+        console.log("loginPrecheckResponseBody: ", loginPrecheckResponseBody);
         if (loginPrecheckResponse.status !== 200) {
           showToastMessage("Failed to login", "error");
           return;
@@ -123,10 +123,10 @@
 
         const saltedPassword = CryptoJS.PBKDF2(
           loginPassword.value,
-          CryptoJS.enc.Hex.parse(loginPrecheckResponseBody.salt),
+          CryptoJS.enc.Hex.parse(loginPrecheckResponseBody.data.salt),
           {
             keySize: 160 / 32,
-            iterations: loginPrecheckResponseBody.iter_count,
+            iterations: loginPrecheckResponseBody.data.iter_count,
             hasher: CryptoJS.algo.SHA1,
           }
         ).toString(CryptoJS.enc.Hex);
@@ -147,7 +147,7 @@
           CryptoJS.enc.Utf8.parse("Server Key")
         ).toString(CryptoJS.enc.Hex);
 
-        const authMessage = `[n=${loginUsername.value},r=${cNonce.value},s=${loginPrecheckResponseBody.salt},i=${loginPrecheckResponseBody.iter_count},r=${loginPrecheckResponseBody.nonce}]`;
+        const authMessage = `[n=${loginUsername.value},r=${cNonce.value},s=${loginPrecheckResponseBody.data.salt},i=${loginPrecheckResponseBody.data.iter_count},r=${loginPrecheckResponseBody.data.nonce}]`;
 
         const clientSignature = CryptoJS.HmacSHA256(
           CryptoJS.enc.Utf8.parse(authMessage),
@@ -172,7 +172,7 @@
             },
             body: JSON.stringify({
               username: loginUsername.value,
-              nonce: loginPrecheckResponseBody.nonce,
+              nonce: loginPrecheckResponseBody.data.nonce,
               c_nonce: cNonce.value,
               client_proof: clientProof,
             }),
@@ -181,14 +181,14 @@
 
         const loginUserResponseJSON = await loginUserResponse.json();
 
-        if (loginUserResponseJSON.server_signature) {
+        if (loginUserResponseJSON.data.server_signature) {
           const serverSignatureCheck = CryptoJS.HmacSHA256(
             CryptoJS.enc.Utf8.parse(authMessage),
             CryptoJS.enc.Hex.parse(serverKey)
           ).toString(CryptoJS.enc.Hex);
 
-          if (serverSignatureCheck === loginUserResponseJSON.server_signature) {
-            token.value = loginUserResponseJSON.token;
+          if (serverSignatureCheck === loginUserResponseJSON.data.server_signature) {
+            token.value = loginUserResponseJSON.data.token;
             localStorage.setItem("token", token.value);
             showToastMessage("Login successful!", "success");
             window.location.href = "[[ .ProxyURL ]]/user";

--- a/server/assets-v1/templates/src/pages/user_portal/login_v2.html
+++ b/server/assets-v1/templates/src/pages/user_portal/login_v2.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/assets-v1/templates/assets/styles/output.css" />
+  <link rel="stylesheet" href="/assets-v1/templates/assets/styles/base.css" />
+  <title>Authentication Page</title>
+  <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+
+  <script src="../assets-v1/templates/assets/js/bundled.js"></script>
+</head>
+
+<body>
+  <div id="app">
+    <div id="navbar" class="user-container">
+      <div class="bg-white flex justify-center items-center my-4">
+        <img src="../assets-v1/images/L8Logo.png" alt="Layer8" width="250" height="535" />
+      </div>
+    </div>
+    <div id="body" class="bg-[#F6F8FF] md:grid md:grid-cols-2">
+      <div class="self-center py-4 md:py-0 mx-10 lg:mx-36 md:mx-18">
+        <h1 class="font-bold text-[#4F80E1] text-[40px] text-start mb-2">
+          Login
+        </h1>
+        <p class="font-normal text-xl text-[#414141] text-start mb-12">
+          Enter your email and password to login.
+        </p>
+        <div>
+          <div class="mb-6">
+            <label class="text-sm text-[#414141] mb-1 block">Username</label>
+            <input
+              class="w-full bg-white rounded-md border border-[#EADFD8] py-2.5 px-3 placeholder:text-[#414141] focus:outline-none"
+              v-model="loginUsername" placeholder="Username" />
+          </div>
+          <div class="mb-12">
+            <label class="text-sm text-[#414141] mb-1 block">Password</label>
+            <input
+              class="w-full bg-white rounded-md border border-[#EADFD8] py-2.5 px-3 placeholder:text-[#414141] focus:outline-none"
+              v-model="loginPassword" type="password" placeholder="Password" />
+          </div>
+          <a class="text-sm text-[#414141] font-normal text-center block cursor-pointer"
+            href="/reset-password-page">Forgot your password?</a>
+          <button class="w-full bg-[#4F80E1] rounded-lg text-center text-white py-4 mb-12" @click="loginUser">
+            Login
+          </button>
+          <a class="text-sm text-[#414141] font-normal text-center block cursor-pointer"
+            href="/v2/user-register-page">Don't have an account? <span class="font-bold">Register</span></a>
+        </div>
+      </div>
+      <div class="bg-white hidden md:flex lg:flex items-center">
+        <img src="/assets-v1/templates/assets/images/cyber-phone.png" />
+      </div>
+    </div>
+    <div id="footer" class="user-container">
+      <div class="bg-white flex justify-between items-center my-8">
+        <div>
+          <img src="../assets-v1/images/L8Logo.png" alt="Layer8" class="mb-6 md:mb-12 h-[35px] md:w-full md:h-[70px]" />
+          <p class="font-bold text-sm md:text-base text-black text-start self-end">
+            ©Layer8security 2023.
+          </p>
+        </div>
+        <div>
+          <div class="text-xl font-bold text-black text-end md:text-start mb-0 md:mb-4 lg:mb-6">
+            Contact
+          </div>
+          <ul class="font-medium text-sm md:text-base text-black text-end md:text-start self-end">
+            <li>Email: hi@layer8.com</li>
+            <li>Client Support: support@layer8.com</li>
+            <li>Phone number: 0371 525 777</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div :class="showToast ? 'opacity-100' : 'opacity-0 pointer-events-none'"
+      class="fixed top-3 right-3 bg-red-500 text-white p-2 rounded-md transition-opacity ease-in-out duration-500 z-50">
+      {{ toastMessage }}
+    </div>
+  </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/crypto-js.min.js"></script>
+  <script>
+    const { createApp, computed, ref } = Vue;
+    const loginUsername = ref("");
+    const loginPassword = ref("");
+    const token = ref(localStorage.getItem("token") || null);
+    const showToast = ref(false);
+    const toastMessage = ref("");
+    const cNonce = ref("");
+    const isLoggedIn = computed(() => token.value !== null);
+
+    const loginUser = async () => {
+      try {
+        if (loginUsername.value === "" || loginPassword.value === "") {
+          showToastMessage("Please enter a username and password!", "error");
+          return;
+        }
+
+        const cNonceLength = 32;
+        const cNonceBytes = new Uint8Array(cNonceLength);
+        window.crypto.getRandomValues(cNonceBytes);
+        cNonce.value = btoa(String.fromCharCode(...cNonceBytes));
+
+        const loginPrecheckResponse = await window.fetch(
+          "[[ .ProxyURL ]]/api/v2/login-precheck",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: loginUsername.value,
+              c_nonce: cNonce.value,
+            }),
+          }
+        );
+        const loginPrecheckResponseBody = await loginPrecheckResponse.json();
+
+        if (loginPrecheckResponse.status !== 200) {
+          showToastMessage("Failed to login", "error");
+          return;
+        }
+
+        const saltedPassword = CryptoJS.PBKDF2(
+          loginPassword.value,
+          CryptoJS.enc.Hex.parse(loginPrecheckResponseBody.salt),
+          {
+            keySize: 160 / 32,
+            iterations: loginPrecheckResponseBody.iter_count,
+            hasher: CryptoJS.algo.SHA1,
+          }
+        ).toString(CryptoJS.enc.Hex);
+
+        const clientKey = CryptoJS.HmacSHA256(
+          CryptoJS.enc.Hex.parse(saltedPassword),
+          CryptoJS.enc.Utf8.parse("Client Key")
+        ).toString(CryptoJS.enc.Hex);
+
+        const clientKeyBytes = hexStringToBytes(clientKey);
+
+        const storedKey = CryptoJS.SHA256(
+          CryptoJS.enc.Hex.parse(clientKey)
+        ).toString(CryptoJS.enc.Hex);
+
+        const serverKey = CryptoJS.HmacSHA256(
+          CryptoJS.enc.Hex.parse(saltedPassword),
+          CryptoJS.enc.Utf8.parse("Server Key")
+        ).toString(CryptoJS.enc.Hex);
+
+        const authMessage = `[n=${loginUsername.value},r=${cNonce.value},s=${loginPrecheckResponseBody.salt},i=${loginPrecheckResponseBody.iter_count},r=${loginPrecheckResponseBody.nonce}]`;
+
+        const clientSignature = CryptoJS.HmacSHA256(
+          CryptoJS.enc.Utf8.parse(authMessage),
+          CryptoJS.enc.Hex.parse(storedKey)
+        ).toString(CryptoJS.enc.Hex);
+
+        const clientSignatureBytes = hexStringToBytes(clientSignature);
+
+        const clientProofBytes = xorBytes(
+          clientKeyBytes,
+          clientSignatureBytes
+        );
+
+        const clientProof = bytesToHexString(clientProofBytes);
+
+        const loginUserResponse = await window.fetch(
+          "[[ .ProxyURL ]]/api/v2/login-user",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: loginUsername.value,
+              nonce: loginPrecheckResponseBody.nonce,
+              c_nonce: cNonce.value,
+              client_proof: clientProof,
+            }),
+          }
+        );
+
+        const loginUserResponseJSON = await loginUserResponse.json();
+
+        if (loginUserResponseJSON.server_signature) {
+          const serverSignatureCheck = CryptoJS.HmacSHA256(
+            CryptoJS.enc.Utf8.parse(authMessage),
+            CryptoJS.enc.Hex.parse(serverKey)
+          ).toString(CryptoJS.enc.Hex);
+
+          if (serverSignatureCheck === loginUserResponseJSON.server_signature) {
+            token.value = loginUserResponseJSON.token;
+            localStorage.setItem("token", token.value);
+            showToastMessage("Login successful!", "success");
+            window.location.href = "[[ .ProxyURL ]]/user";
+          }
+        } else if (loginUserResponseJSON.message) {
+          showToastMessage(loginUserResponseJSON.message, "error");
+        } else {
+          showToastMessage("Login failed, please try again later", "error");
+        }
+      } catch (error) {
+        console.error(error);
+        showToastMessage("Login failed!", "error");
+      }
+    };
+
+    const showToastMessage = (message, type) => {
+      // Current param type is not used. But will be in the future
+      toastMessage.value = message;
+      showToast.value = true;
+      setTimeout(() => {
+        showToast.value = false;
+      }, 3000);
+    };
+
+    function hexStringToBytes(hex) {
+      const bytes = [];
+      for (let i = 0; i < hex.length; i += 2) {
+        bytes.push(parseInt(hex.substr(i, 2), 16));
+      }
+      return bytes;
+    }
+
+    function bytesToHexString(bytes) {
+      return bytes.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
+
+    function xorBytes(bytesA, bytesB) {
+      return bytesA.map((byte, index) => byte ^ bytesB[index]);
+    }
+
+    const app = createApp({
+      setup() {
+        return {
+          loginUser,
+          isLoggedIn,
+          loginUsername,
+          loginPassword,
+          toastMessage,
+          showToast,
+        };
+      },
+    });
+
+    app.mount("#app");
+  </script>
+</body>
+
+</html>

--- a/server/assets-v1/templates/src/pages/user_portal/password_reset/reset-password-page_v2.html
+++ b/server/assets-v1/templates/src/pages/user_portal/password_reset/reset-password-page_v2.html
@@ -172,7 +172,7 @@
 
                 if (resetPasswordResponseBody.is_success === true) {
                     alert(resetPasswordResponseBody.message);
-                    window.location.href = "[[ .ProxyURL ]]/user-login-page";
+                    window.location.href = "[[ .ProxyURL ]]/v2/user-login-page";
                 } else {
                     console.log(resetPasswordResponseBody.errors);
                     alert("Error: " + resetPasswordResponseBody.message);

--- a/server/assets-v1/templates/src/pages/user_portal/register_v2.html
+++ b/server/assets-v1/templates/src/pages/user_portal/register_v2.html
@@ -102,7 +102,7 @@
             </button>
             <a
               class="text-sm text-[#414141] font-normal text-center block cursor-pointer"
-              href="/user-login-page"
+              href="/v2/user-login-page"
               >Already have an account? <span class="font-bold">Login</span></a
             >
           </div>
@@ -228,7 +228,7 @@
       };
 
       const backToLogin = async () => {
-        window.location.href = "[[ .ProxyURL ]]/user-login-page";
+        window.location.href = "[[ .ProxyURL ]]/v2/user-login-page";
       };
 
       const registerUser = async () => {

--- a/server/cmd/app/main.go
+++ b/server/cmd/app/main.go
@@ -249,6 +249,8 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 				Ctl.UserHandler(w, r)
 			case path == "/user-login-page":
 				Ctl.LoginUserPage(w, r)
+			case path == "/v2/user-login-page":
+				Ctl.LoginUserPagev2(w, r)
 			case path == "/user-register-page":
 				Ctl.RegisterUserPage(w, r)
 			case path == "/v2/user-register-page":
@@ -275,8 +277,12 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 				Ctl.GetClientData(w, r)
 			case path == "/api/v1/login-precheck":
 				Ctl.LoginPrecheckHandler(w, r)
+			case path == "/api/v2/login-precheck":
+				Ctl.LoginPrecheckHandlerv2(w, r)
 			case path == "/api/v1/login-user":
 				Ctl.LoginUserHandler(w, r)
+			case path == "/api/v2/login-user":
+				Ctl.LoginUserHandlerv2(w, r)
 			case path == "/api/v1/login-client":
 				Ctl.LoginClientHandler(w, r) // Login Client
 			case path == "/api/v1/profile":

--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -226,7 +226,7 @@ func LoginPrecheckHandlerv2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	loginPrecheckResp, err := newService.LoginPreCheckUserv2(request)
+	loginPrecheckResp, err := newService.LoginPrecheckUserv2(request)
 	if err != nil {
 		utils.HandleError(w, http.StatusBadRequest, "Failed to perform precheck, service error", err)
 		return

--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -23,6 +23,9 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 func LoginUserPage(w http.ResponseWriter, r *http.Request) {
 	ServeFileHandler(w, r, "assets-v1/templates/src/pages/user_portal/login.html")
 }
+func LoginUserPagev2(w http.ResponseWriter, r *http.Request) {
+	ServeFileHandler(w, r, "assets-v1/templates/src/pages/user_portal/login_v2.html")
+}
 func RegisterUserPage(w http.ResponseWriter, r *http.Request) {
 	ServeFileHandler(w, r, "assets-v1/templates/src/pages/user_portal/register.html")
 }
@@ -211,6 +214,34 @@ func LoginPrecheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func LoginPrecheckHandlerv2(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
+	newService := r.Context().Value("service").(interfaces.IService)
+
+	request, err := utils.DecodeJsonFromRequest[dto.LoginPrecheckDTOv2](w, r.Body)
+	if err != nil {
+		return
+	}
+
+	loginPrecheckResp, err := newService.LoginPreCheckUserv2(request)
+	if err != nil {
+		utils.HandleError(w, http.StatusBadRequest, "Failed to perform precheck, service error", err)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(loginPrecheckResp); err != nil {
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
+	}
+}
+
 func LoginUserHandler(w http.ResponseWriter, r *http.Request) {
 	if !validateHttpMethod(w, r.Method, http.MethodPost) {
 		return
@@ -230,6 +261,34 @@ func LoginUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(tokenResp); err != nil {
+		utils.HandleError(
+			w,
+			http.StatusInternalServerError,
+			"Internal error: could not encode response into json",
+			err,
+		)
+	}
+}
+
+func LoginUserHandlerv2(w http.ResponseWriter, r *http.Request) {
+	if !validateHttpMethod(w, r.Method, http.MethodPost) {
+		return
+	}
+
+	newService := r.Context().Value("service").(interfaces.IService)
+
+	request, err := utils.DecodeJsonFromRequest[dto.LoginUserDTOv2](w, r.Body)
+	if err != nil {
+		return
+	}
+
+	serverSignatureResp, err := newService.LoginUserv2(request)
+	if err != nil {
+		utils.HandleError(w, http.StatusBadRequest, "Failed to perform login", err)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(serverSignatureResp); err != nil {
 		utils.HandleError(
 			w,
 			http.StatusInternalServerError,

--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -236,7 +236,9 @@ func LoginPrecheckHandlerv2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(loginPrecheckResp); err != nil {
+	response := utils.BuildResponse(w, http.StatusOK, "Precheck successful", loginPrecheckResp)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		utils.HandleError(
 			w,
 			http.StatusInternalServerError,
@@ -292,7 +294,9 @@ func LoginUserHandlerv2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(serverSignatureResp); err != nil {
+	response := utils.BuildResponse(w, http.StatusOK, "Login successful", serverSignatureResp)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		utils.HandleError(
 			w,
 			http.StatusInternalServerError,

--- a/server/resource_server/controller/controller_test.go
+++ b/server/resource_server/controller/controller_test.go
@@ -724,15 +724,21 @@ func TestLoginPrecheckHandlerv2_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Decode the response body
-	var response models.LoginPrecheckResponseOutputv2
+	var response utils.Response
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatal(err)
 	}
 
+	salt := response.Data.(map[string]interface{})["salt"]
+
+	nonce := response.Data.(map[string]interface{})["nonce"]
+
+	iterCount := response.Data.(map[string]interface{})["iter_count"]
+
 	// Now assert the fields directly
-	assert.Equal(t, userSalt, response.Salt)
-	assert.Equal(t, iterCount, response.IterCount)
-	assert.Equal(t, nonce, response.Nonce)
+	assert.Equal(t, userSalt, salt)
+	assert.Equal(t, iterCount, iterCount)
+	assert.Equal(t, nonce, nonce)
 }
 
 func TestLoginUserHandler_InvalidHttpRequestMethod(t *testing.T) {
@@ -1015,14 +1021,18 @@ func TestLoginUserHandlerv2_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Decode the response body
-	var response models.LoginUserResponseOutputv2
+	var response utils.Response
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatal(err)
 	}
 
+	token := response.Data.(map[string]interface{})["token"]
+
+	server_signature := response.Data.(map[string]interface{})["server_signature"]
+
 	// Now assert the fields directly
-	assert.Equal(t, testToken, response.Token)
-	assert.Equal(t, serverSignature, response.ServerSignature)
+	assert.Equal(t, testToken, token)
+	assert.Equal(t, serverSignature, server_signature)
 }
 
 func TestProfileHandler_InvalidHttpRequestMethod(t *testing.T) {

--- a/server/resource_server/dto/dto.go
+++ b/server/resource_server/dto/dto.go
@@ -27,6 +27,13 @@ type LoginUserDTO struct {
 	Salt     string `json:"salt" validate:"required"`
 }
 
+type LoginUserDTOv2 struct {
+	Username    string `json:"username" validate:"required"`
+	Nonce       string `json:"nonce" validate:"required"`
+	CNonce      string `json:"c_nonce" validate:"required"`
+	ClientProof string `json:"client_proof" validate:"required"`
+}
+
 type LoginClientDTO struct {
 	Username string `json:"username" validate:"required"`
 	Password string `json:"password" validate:"required"`
@@ -34,6 +41,11 @@ type LoginClientDTO struct {
 
 type LoginPrecheckDTO struct {
 	Username string `json:"username" validate:"required"`
+}
+
+type LoginPrecheckDTOv2 struct {
+	Username string `json:"username" validate:"required"`
+	CNonce   string `json:"c_nonce" validate:"required"`
 }
 
 type UpdateDisplayNameDTO struct {

--- a/server/resource_server/interfaces/service.go
+++ b/server/resource_server/interfaces/service.go
@@ -9,8 +9,10 @@ type IService interface {
 	RegisterUser(req dto.RegisterUserDTO) error
 	RegisterUserv2(req dto.RegisterUserDTOv2) error
 	LoginPreCheckUser(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error)
+	LoginPreCheckUserv2(req dto.LoginPrecheckDTOv2) (models.LoginPrecheckResponseOutputv2, error)
 	LoginPreCheckClient(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error)
 	LoginUser(req dto.LoginUserDTO) (models.LoginUserResponseOutput, error)
+	LoginUserv2(req dto.LoginUserDTOv2) (models.LoginUserResponseOutputv2, error)
 	LoginClient(req dto.LoginClientDTO) (models.LoginUserResponseOutput, error)
 	ProfileUser(userID uint) (models.ProfileResponseOutput, error)
 	ProfileClient(userID string) (models.ClientResponseOutput, error)

--- a/server/resource_server/interfaces/service.go
+++ b/server/resource_server/interfaces/service.go
@@ -9,7 +9,7 @@ type IService interface {
 	RegisterUser(req dto.RegisterUserDTO) error
 	RegisterUserv2(req dto.RegisterUserDTOv2) error
 	LoginPreCheckUser(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error)
-	LoginPreCheckUserv2(req dto.LoginPrecheckDTOv2) (models.LoginPrecheckResponseOutputv2, error)
+	LoginPrecheckUserv2(req dto.LoginPrecheckDTOv2) (models.LoginPrecheckResponseOutputv2, error)
 	LoginPreCheckClient(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error)
 	LoginUser(req dto.LoginUserDTO) (models.LoginUserResponseOutput, error)
 	LoginUserv2(req dto.LoginUserDTOv2) (models.LoginUserResponseOutputv2, error)

--- a/server/resource_server/models/response.go
+++ b/server/resource_server/models/response.go
@@ -5,8 +5,19 @@ type LoginPrecheckResponseOutput struct {
 	Salt     string `json:"salt"`
 }
 
+type LoginPrecheckResponseOutputv2 struct {
+	Salt      string `json:"salt"`
+	IterCount int    `json:"iter_count"`
+	Nonce     string `json:"nonce"`
+}
+
 type LoginUserResponseOutput struct {
 	Token string `json:"token"`
+}
+
+type LoginUserResponseOutputv2 struct {
+	ServerSignature string `json:"server_signature"`
+	Token           string `json:"token"`
 }
 
 type ProfileResponseOutput struct {

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -164,7 +164,7 @@ func (s *service) LoginUserv2(req dto.LoginUserDTOv2) (models.LoginUserResponseO
 	clientSignatureHMAC.Write(authMessageBytes)
 	clientSignature := clientSignatureHMAC.Sum(nil)
 
-	clientProofBytes, err := utils.HexStringToBytes(req.ClientProof)
+	clientProofBytes, err := hex.DecodeString(req.ClientProof)
 	if err != nil {
 		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error decoding client proof: %v", err)
 	}
@@ -174,9 +174,9 @@ func (s *service) LoginUserv2(req dto.LoginUserDTOv2) (models.LoginUserResponseO
 		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error performing XOR operation: %v", err)
 	}
 
-	cleintKeyHash := sha256.Sum256(clientKeyBytes)
+	clientKeyHash := sha256.Sum256(clientKeyBytes)
 
-	clientKeyHashStr := hex.EncodeToString(cleintKeyHash[:])
+	clientKeyHashStr := hex.EncodeToString(clientKeyHash[:])
 	if clientKeyHashStr != user.StoredKey {
 		return models.LoginUserResponseOutputv2{}, fmt.Errorf("server failed to authenticate the user")
 	}

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"globe-and-citizen/layer8/server/resource_server/dto"
 	"globe-and-citizen/layer8/server/resource_server/emails/verification"
@@ -104,6 +107,21 @@ func (s *service) LoginPreCheckUser(req dto.LoginPrecheckDTO) (models.LoginPrech
 	return loginPrecheckResp, nil
 }
 
+func (s *service) LoginPreCheckUserv2(req dto.LoginPrecheckDTOv2) (models.LoginPrecheckResponseOutputv2, error) {
+	sNonce := utils.GenerateRandomSalt(32)
+
+	user, err := s.repository.GetUserForUsername(req.Username)
+	if err != nil {
+		return models.LoginPrecheckResponseOutputv2{}, err
+	}
+	loginPrecheckResp := models.LoginPrecheckResponseOutputv2{
+		Salt:      user.Salt,
+		IterCount: user.IterationCount,
+		Nonce:     req.CNonce + sNonce,
+	}
+	return loginPrecheckResp, nil
+}
+
 func (s *service) LoginPreCheckClient(req dto.LoginPrecheckDTO) (models.LoginPrecheckResponseOutput, error) {
 	username, salt, err := s.repository.LoginPreCheckClient(req)
 	if err != nil {
@@ -126,6 +144,61 @@ func (s *service) LoginUser(req dto.LoginUserDTO) (models.LoginUserResponseOutpu
 		return models.LoginUserResponseOutput{}, err
 	}
 	return tokenResp, nil
+}
+
+func (s *service) LoginUserv2(req dto.LoginUserDTOv2) (models.LoginUserResponseOutputv2, error) {
+	user, err := s.repository.GetUserForUsername(req.Username)
+	if err != nil {
+		return models.LoginUserResponseOutputv2{}, err
+	}
+
+	storedKeyBytes, err := hex.DecodeString(user.StoredKey)
+	if err != nil {
+		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error decoding stored key: %v", err)
+	}
+
+	authMessage := fmt.Sprintf("[n=%s,r=%s,s=%s,i=%d,r=%s]", req.Username, req.CNonce, user.Salt, user.IterationCount, req.Nonce)
+	authMessageBytes := []byte(authMessage)
+
+	clientSignatureHMAC := hmac.New(sha256.New, storedKeyBytes)
+	clientSignatureHMAC.Write(authMessageBytes)
+	clientSignature := clientSignatureHMAC.Sum(nil)
+
+	clientProofBytes, err := utils.HexStringToBytes(req.ClientProof)
+	if err != nil {
+		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error decoding client proof: %v", err)
+	}
+
+	clientKeyBytes, err := utils.XorBytes(clientSignature, clientProofBytes)
+	if err != nil {
+		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error performing XOR operation: %v", err)
+	}
+
+	cleintKeyHash := sha256.Sum256(clientKeyBytes)
+
+	clientKeyHashStr := hex.EncodeToString(cleintKeyHash[:])
+	if clientKeyHashStr != user.StoredKey {
+		return models.LoginUserResponseOutputv2{}, fmt.Errorf("server failed to authenticate the user")
+	}
+
+	serverKeyBytes, err := hex.DecodeString(user.ServerKey)
+	if err != nil {
+		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error decoding server key: %v", err)
+	}
+
+	serverSignatureHMAC := hmac.New(sha256.New, serverKeyBytes)
+	serverSignatureHMAC.Write(authMessageBytes)
+	serverSignatureHex := hex.EncodeToString(serverSignatureHMAC.Sum(nil))
+
+	tokenString, err := utils.GenerateToken(user)
+	if err != nil {
+		return models.LoginUserResponseOutputv2{}, fmt.Errorf("error generating token: %v", err)
+	}
+
+	return models.LoginUserResponseOutputv2{
+		ServerSignature: serverSignatureHex,
+		Token:           tokenString,
+	}, nil
 }
 
 func (s *service) LoginClient(req dto.LoginClientDTO) (models.LoginUserResponseOutput, error) {

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -107,8 +107,8 @@ func (s *service) LoginPreCheckUser(req dto.LoginPrecheckDTO) (models.LoginPrech
 	return loginPrecheckResp, nil
 }
 
-func (s *service) LoginPreCheckUserv2(req dto.LoginPrecheckDTOv2) (models.LoginPrecheckResponseOutputv2, error) {
-	sNonce := utils.GenerateRandomSalt(32)
+func (s *service) LoginPrecheckUserv2(req dto.LoginPrecheckDTOv2) (models.LoginPrecheckResponseOutputv2, error) {
+	sNonce := utils.GenerateRandomSalt(utils.SaltSize)
 
 	user, err := s.repository.GetUserForUsername(req.Username)
 	if err != nil {

--- a/server/resource_server/service/service_test.go
+++ b/server/resource_server/service/service_test.go
@@ -22,8 +22,8 @@ import (
 
 const userId uint = 1
 const adminEmail = "admin@email.com"
-const username = "user"
-const password = "password"
+const username = "test_user"
+const password = "1234"
 const userEmail = "user@email.com"
 const firstName = "first_name"
 const lastName = "second_name"
@@ -32,8 +32,14 @@ const country = "country"
 const verificationCode = "123456"
 const userSalt = "salt"
 const publicKey = "0xaaaaa"
-const serverKey = "0xbbbbb"
-const storedKey = "0xccccc"
+const cNonce = "1a7fa8e9dc2a68049358a08349cdde50"
+const nonce = "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362"
+const clientProof = "96260616beaabaa6d168b9ce7e15b127b6bcbcb88fd0b5de1e6162b948881155"
+const storedKey = "222f705167604c99f81c7c6acfa974706fa9dd0b445a8bc34fb5accc9b032558"
+const serverKey = "f6e938506893b10799038c2b4225f7e8e72f01c7ab25c3da905803ee93ec5536"
+const salt = "c8f720569d7a50d4c812431cf8a242fd608f3a5b4610659b92f6aa553fbe68e0"
+const iterationCount = 4096
+const testServerSignature = "138c0fecd0326896fe21398137c1aa0b9866242abc02bd3e9a5a0016013ef5f0"
 
 const redirectUri = "redirect_uri"
 const backendUri = "backend_uri"
@@ -455,10 +461,10 @@ func TestLoginUserV2_RepositoryError(t *testing.T) {
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
-		ClientProof: "96260616beaabaa6d168b9ce7e15b127b6bcbcb88fd0b5de1e6162b948881155",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
+		ClientProof: clientProof,
 	}
 
 	loginUserResp, err := currService.LoginUserv2(req)
@@ -479,10 +485,10 @@ func TestLoginUserV2_DecodingStoredKeyError(t *testing.T) {
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
-		ClientProof: "96260616beaabaa6d168b9ce7e15b127b6bcbcb88fd0b5de1e6162b948881155",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
+		ClientProof: clientProof,
 	}
 
 	loginUserResp, err := currService.LoginUserv2(req)
@@ -496,18 +502,18 @@ func TestLoginUserV2_DecodingClientProofError(t *testing.T) {
 	mockRepo := &mockRepository{
 		getUserForUsername: func(username string) (models.User, error) {
 			return models.User{
-				StoredKey:      "222f705167604c99f81c7c6acfa974706fa9dd0b445a8bc34fb5accc9b032558",
-				Salt:           "c8f720569d7a50d4c812431cf8a242fd608f3a5b4610659b92f6aa553fbe68e0",
-				IterationCount: 4096,
+				StoredKey:      storedKey,
+				Salt:           salt,
+				IterationCount: iterationCount,
 			}, nil
 		},
 	}
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
 		ClientProof: "TEST_CLIENT_PROOF_FOR_DECODE_ERROR_!@#", // Invalid client proof
 	}
 
@@ -522,18 +528,18 @@ func TestLoginUserV2_XorOperationError(t *testing.T) {
 	mockRepo := &mockRepository{
 		getUserForUsername: func(username string) (models.User, error) {
 			return models.User{
-				StoredKey:      "222f705167604c99f81c7c6acfa974706fa9dd0b445a8bc34fb5accc9b032558",
-				Salt:           "c8f720569d7a50d4c812431cf8a242fd608f3a5b4610659b92f6aa553fbe68e0",
-				IterationCount: 4096,
+				StoredKey:      storedKey,
+				Salt:           salt,
+				IterationCount: iterationCount,
 			}, nil
 		},
 	}
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
 		ClientProof: "", // Sending empty client proof to fail the XOR operation, since it requires equal length slices
 	}
 
@@ -549,18 +555,18 @@ func TestLoginUserV2_AuthFailedKeyMismatchError(t *testing.T) {
 		getUserForUsername: func(username string) (models.User, error) {
 			return models.User{
 				StoredKey:      "", // Empty stored key
-				Salt:           "c8f720569d7a50d4c812431cf8a242fd608f3a5b4610659b92f6aa553fbe68e0",
-				IterationCount: 4096,
+				Salt:           salt,
+				IterationCount: iterationCount,
 			}, nil
 		},
 	}
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
-		ClientProof: "96260616beaabaa6d168b9ce7e15b127b6bcbcb88fd0b5de1e6162b948881155",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
+		ClientProof: clientProof,
 	}
 
 	loginUserResp, err := currService.LoginUserv2(req)
@@ -574,20 +580,20 @@ func TestLoginUserV2_DecodingServerKeyError(t *testing.T) {
 	mockRepo := &mockRepository{
 		getUserForUsername: func(username string) (models.User, error) {
 			return models.User{
-				StoredKey:      "222f705167604c99f81c7c6acfa974706fa9dd0b445a8bc34fb5accc9b032558",
+				StoredKey:      storedKey,
 				ServerKey:      "TEST_SERVER_KEY_FOR_DECODE_ERROR_!@#", // Invalid server key
-				Salt:           "c8f720569d7a50d4c812431cf8a242fd608f3a5b4610659b92f6aa553fbe68e0",
-				IterationCount: 4096,
+				Salt:           salt,
+				IterationCount: iterationCount,
 			}, nil
 		},
 	}
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
-		ClientProof: "96260616beaabaa6d168b9ce7e15b127b6bcbcb88fd0b5de1e6162b948881155",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
+		ClientProof: clientProof,
 	}
 
 	loginUserResp, err := currService.LoginUserv2(req)
@@ -601,26 +607,26 @@ func TestLoginUserV2_Success(t *testing.T) {
 	mockRepo := &mockRepository{
 		getUserForUsername: func(username string) (models.User, error) {
 			return models.User{
-				StoredKey:      "222f705167604c99f81c7c6acfa974706fa9dd0b445a8bc34fb5accc9b032558",
-				ServerKey:      "f6e938506893b10799038c2b4225f7e8e72f01c7ab25c3da905803ee93ec5536",
-				Salt:           "c8f720569d7a50d4c812431cf8a242fd608f3a5b4610659b92f6aa553fbe68e0",
-				IterationCount: 4096,
+				StoredKey:      storedKey,
+				ServerKey:      serverKey,
+				Salt:           salt,
+				IterationCount: iterationCount,
 			}, nil
 		},
 	}
 	currService := service.NewService(mockRepo, &verification.EmailVerifier{}, &mocks.MockProofGenerator{})
 
 	req := dto.LoginUserDTOv2{
-		Username:    "test_user",
-		CNonce:      "1a7fa8e9dc2a68049358a08349cdde50",
-		Nonce:       "1a7fa8e9dc2a68049358a08349cdde50d6d6f9c5e632f599881d99fe9c62b362",
-		ClientProof: "96260616beaabaa6d168b9ce7e15b127b6bcbcb88fd0b5de1e6162b948881155",
+		Username:    username,
+		CNonce:      cNonce,
+		Nonce:       nonce,
+		ClientProof: clientProof,
 	}
 
 	loginUserResp, err := currService.LoginUserv2(req)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "138c0fecd0326896fe21398137c1aa0b9866242abc02bd3e9a5a0016013ef5f0", loginUserResp.ServerSignature)
+	assert.Equal(t, testServerSignature, loginUserResp.ServerSignature)
 }
 
 func TestProfileUser(t *testing.T) {

--- a/server/resource_server/service/service_test.go
+++ b/server/resource_server/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"globe-and-citizen/layer8/server/resource_server/service"
 	"globe-and-citizen/layer8/server/resource_server/utils"
 	"globe-and-citizen/layer8/server/resource_server/utils/mocks"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,9 +71,7 @@ type mockRepository struct {
 	findUser                     func(userId uint) (models.User, error)
 	saveEmailVerificationData    func(data models.EmailVerificationData) error
 	getEmailVerificationData     func(userId uint) (models.EmailVerificationData, error)
-	// deleteEmailVerificationData  func(userId uint) error
 	saveProofOfEmailVerification func(userID uint, verificationCode string, proof []byte, zkKeyPairId uint) error
-	// setUserEmailVerified         func(userID uint) error
 	registerUser                 func(req dto.RegisterUserDTO, hashedPassword string, salt string) error
 	registerUserPrecheck         func(req dto.RegisterUserPrecheckDTO, salt string, iterCount int) error
 	registerUserv2               func(req dto.RegisterUserDTOv2) error
@@ -413,7 +412,7 @@ func TestLoginPreCheckUserV2_Success(t *testing.T) {
 			return models.User{
 				Username:       username,
 				Salt:           salt,
-				IterationCount: 4096,
+				IterationCount: iterationCount,
 			}, nil
 		},
 	}
@@ -429,7 +428,8 @@ func TestLoginPreCheckUserV2_Success(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, loginPrecheckResp.Salt, salt)
-	assert.Equal(t, loginPrecheckResp.IterCount, 4096)
+	assert.Equal(t, strings.HasPrefix(loginPrecheckResp.Nonce, cNonce), true)
+	assert.Equal(t, loginPrecheckResp.IterCount, iterationCount)
 }
 
 func TestLoginUser(t *testing.T) {

--- a/server/resource_server/utils/utils.go
+++ b/server/resource_server/utils/utils.go
@@ -262,3 +262,27 @@ func RemoveProtocolFromURL(url string) string {
 	cleanedURL = strings.Replace(cleanedURL, "https://", "", -1)
 	return cleanedURL
 }
+
+func HexStringToBytes(hexStr string) ([]byte, error) {
+	bytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+func BytesToHexString(bytes []byte) string {
+	return hex.EncodeToString(bytes)
+}
+
+func XorBytes(bytesA, bytesB []byte) ([]byte, error) {
+	if len(bytesA) != len(bytesB) {
+		return nil, fmt.Errorf("slices must have the same length")
+	}
+
+	result := make([]byte, len(bytesA))
+	for i := range bytesA {
+		result[i] = bytesA[i] ^ bytesB[i]
+	}
+	return result, nil
+}

--- a/server/resource_server/utils/utils.go
+++ b/server/resource_server/utils/utils.go
@@ -263,18 +263,6 @@ func RemoveProtocolFromURL(url string) string {
 	return cleanedURL
 }
 
-func HexStringToBytes(hexStr string) ([]byte, error) {
-	bytes, err := hex.DecodeString(hexStr)
-	if err != nil {
-		return nil, err
-	}
-	return bytes, nil
-}
-
-func BytesToHexString(bytes []byte) string {
-	return hex.EncodeToString(bytes)
-}
-
 func XorBytes(bytesA, bytesB []byte) ([]byte, error) {
 	if len(bytesA) != len(bytesB) {
 		return nil, fmt.Errorf("slices must have the same length")


### PR DESCRIPTION
## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] Created a new user on the Layer8 Portal

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [ ] Login as 'tester', '1234'
- [ ] Choose login with layer8 
- [ ] Logging in with the newly registered credentials from Section 1 succeeds in popup
- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [ ] Choose poems 1 - 3 works correctly 

### SECTION 3: IMSHARER (http://localhost:5174/)
- [ ] Uploads an image works
- [ ] Reload leads to instant reload (demonstrating proper caching)



#### Summary  
This PR implements the **Login User with SCRAM** flow. I did changes both on the frontend and backend as per the issue: https://github.com/globe-and-citizen/layer8/issues/165. Both the login-precheck and login-user endpoints are currently under `/v2` path to avoid breaking the current flow. More details are as follows:

**Frontend**  
1. Added new frontend page: `/v2/user-login-page` for the SCRAM login specifically.
2. After login-precheck is successful from the backend side, and the response (salt, iterationCount, nonce) comes to the frontend, the frontend then generates the following:
- Salted Password
- Client Key
- Server Key
- Auth Message
- Client Signature
- Client Proof
(More details regarding each of the above can be seen in issue: https://github.com/globe-and-citizen/layer8/issues/165 figure, in the description)
3. Once the success response comes from the backend's `/api/v2/login-user` endpoint, then frontend validates the `ServerSignature` using `ServerKey`.

**Backend**  
1. Added new endpoint: `/api/v2/login-precheck` for User Precheck before login, which recieves username and c-nonce in the request, and returns salt, iterationCount, & nonce in the response
2. Added new endpoint: `/api/v2/login-user` which gets triggered after precheck.This endpoint performs the following:
- Get user details from database against the username
- Make up the `AuthMessage`
- Generate `ClientSignature`
- Generate `ClientKey`
- Assert that `storedKey == SHA256(ClientKey)`
- Generate `ServerSignature`
- Return `ServerSignature` along with `JWT TOKEN`

#### Testing  
- Added unit tests for controller layer (For both `LoginPrecheckHandlerv2` & `LoginUserHandlerv2`)
- Added unit tests for service layer (For both `LoginPrecheckHandlerv2` & `LoginUserHandlerv2`)
- No tests for repository layer (Since no new code is added there)