### PR TITLE
feat: health_check handler for the tunnel

### DIFF
--- a/server/cmd/app/main.go
+++ b/server/cmd/app/main.go
@@ -328,6 +328,9 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 				handlers.InitTunnel(w, r)
 			case path == "/error":
 				handlers.TestError(w, r)
+			case path == "/health_check":
+				handlers.HealthCheck(w, r)
+
 				// TODO: For later, to be discussed more
 				// case path == "/tunnel":
 				// 	handlers.Tunnel(w, r)

--- a/server/handlers/health_check.go
+++ b/server/handlers/health_check.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type HealthCheckResponse struct {
+	ForwardProxy *Message `json:"forward_proxy,omitempty"`
+	ReverseProxy *Message `json:"reverse_proxy,omitempty"`
+}
+
+type Message struct {
+	StatusCode int    `json:"status"`
+	Message    string `json:"message,omitempty"`
+	BodyDump   []byte `json:"body_dump,omitempty"`
+}
+
+// Fixme: this is the first iteration of the health check handler, needs a more standardized approach like <https://github.com/alexliesenfeld/health>
+func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	// get the backend url from query params "backend_url"
+	backendURL := r.URL.Query().Get("backend_url")
+	if backendURL == "" {
+		health := HealthCheckResponse{
+			ForwardProxy: &Message{
+				StatusCode: http.StatusBadRequest,
+				Message:    "backend_url is required",
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health)
+		return
+	}
+
+	backendUrlParsed, err := url.JoinPath(backendURL, "l8_health_check")
+	if err != nil {
+		health := HealthCheckResponse{
+			ForwardProxy: &Message{
+				StatusCode: http.StatusBadRequest,
+				Message:    "backend_url is malformed",
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health)
+		return
+	}
+
+	req, err := http.NewRequest("GET", backendUrlParsed, nil)
+	if err != nil {
+		fmt.Println("Useing url", backendURL)
+		fmt.Println("Error", err.Error())
+
+		health := HealthCheckResponse{
+			ForwardProxy: &Message{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "failed to create request",
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health)
+		return
+	}
+
+	req.Header.Set("x-tunnel", "true")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		health := HealthCheckResponse{
+			ForwardProxy: &Message{StatusCode: http.StatusOK},
+			ReverseProxy: &Message{
+				StatusCode: http.StatusBadGateway,
+				Message:    "failed to send request to reverse proxy",
+				BodyDump:   []byte(err.Error()),
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health)
+		return
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error is", err.Error())
+
+		health := HealthCheckResponse{
+			ForwardProxy: &Message{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "failed to read response body",
+				BodyDump:   []byte(err.Error()),
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health)
+		return
+	}
+
+	if resp.StatusCode >= http.StatusInternalServerError {
+		health := HealthCheckResponse{
+			ForwardProxy: &Message{StatusCode: http.StatusOK},
+			ReverseProxy: &Message{
+				StatusCode: resp.StatusCode,
+				Message:    "reverse proxy is not healthy",
+				BodyDump:   data,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health)
+		return
+	}
+
+	health := &HealthCheckResponse{
+		ForwardProxy: &Message{StatusCode: http.StatusOK},
+		ReverseProxy: &Message{
+			StatusCode: resp.StatusCode,
+			Message:    "reverse proxy code is < 500",
+			BodyDump:   data,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(health)
+}

--- a/server/handlers/health_check_test.go
+++ b/server/handlers/health_check_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthCheck(t *testing.T) {
+	tests := []struct {
+		scenario                    string
+		reverseProxyUrl             func() (string, func()) // url and Close fn
+		expectedCodeForwardProxy    int
+		expectedMessageForwardProxy string
+		expectedCodeReverseProxy    int
+		expectedMessageReverseProxy string
+	}{
+		{
+			scenario: "backend_url is empty",
+			reverseProxyUrl: func() (string, func()) {
+				return "", nil
+			},
+			expectedCodeForwardProxy:    http.StatusBadRequest,
+			expectedMessageForwardProxy: "backend_url is required",
+		},
+		{
+			scenario: "failed to send request",
+			reverseProxyUrl: func() (string, func()) {
+				return uuid.NewString(), nil
+			},
+			expectedCodeForwardProxy:    http.StatusOK,
+			expectedCodeReverseProxy:    http.StatusBadGateway,
+			expectedMessageReverseProxy: "failed to send request to reverse proxy",
+		},
+		{
+			scenario: "internal server error from reverse proxy",
+			reverseProxyUrl: func() (string, func()) {
+				internalServerStatusSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+
+				return internalServerStatusSrv.URL, internalServerStatusSrv.Close
+			},
+			expectedCodeForwardProxy:    http.StatusOK,
+			expectedCodeReverseProxy:    http.StatusInternalServerError,
+			expectedMessageReverseProxy: "reverse proxy is not healthy",
+		},
+		{
+			scenario: "ok from reverse proxy",
+			reverseProxyUrl: func() (string, func()) {
+				okServerStatusSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+
+				return okServerStatusSrv.URL, okServerStatusSrv.Close
+			},
+			expectedCodeForwardProxy: http.StatusOK,
+			expectedCodeReverseProxy: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scenario, func(t *testing.T) {
+			var (
+				responseRecorder    = httptest.NewRecorder()
+				healthCheckResponse HealthCheckResponse
+			)
+
+			request := httptest.NewRequest("GET", "/health_check", nil)
+			reverseProxyUrl, closeFn := tt.reverseProxyUrl()
+			if reverseProxyUrl != "" {
+				values := request.URL.Query()
+				values.Add("backend_url", reverseProxyUrl)
+				request.URL.RawQuery = values.Encode()
+			}
+
+			// cleanup test server
+			defer func() {
+				if closeFn != nil {
+					closeFn()
+				}
+			}()
+
+			HealthCheck(responseRecorder, request)
+			assert.NoError(t, json.NewDecoder(responseRecorder.Body).Decode(&healthCheckResponse), "Failed to decode response")
+
+			if tt.expectedCodeForwardProxy > 0 && healthCheckResponse.ForwardProxy != nil {
+				assert.Equal(t, tt.expectedCodeForwardProxy, healthCheckResponse.ForwardProxy.StatusCode, "Expected status code %d", tt.expectedCodeForwardProxy)
+			}
+
+			if tt.expectedMessageForwardProxy != "" && healthCheckResponse.ForwardProxy != nil {
+				assert.Equal(t, tt.expectedMessageForwardProxy, healthCheckResponse.ForwardProxy.Message, "Expected message %s", tt.expectedMessageForwardProxy)
+			}
+
+			if tt.expectedCodeReverseProxy > 0 && healthCheckResponse.ReverseProxy != nil {
+				assert.Equal(t, tt.expectedCodeReverseProxy, healthCheckResponse.ReverseProxy.StatusCode, "Expected status code %d", tt.expectedCodeReverseProxy)
+			}
+
+			if tt.expectedMessageReverseProxy != "" && healthCheckResponse.ReverseProxy != nil {
+				assert.Equal(t, tt.expectedMessageReverseProxy, healthCheckResponse.ReverseProxy.Message, "Expected message %s", tt.expectedMessageReverseProxy)
+			}
+		})
+	}
+}

--- a/server/handlers/tunnel.go
+++ b/server/handlers/tunnel.go
@@ -354,6 +354,10 @@ func wsTunnel(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			fmt.Println("----------------------------------")
+			fmt.Println("Data from client: ", string(data))
+			fmt.Println("--------------------------------")
+
 			if err = serviceProviderSoc.Write(ctx, websocket.MessageText, data); err != nil {
 				if isNormal(err) {
 					return

--- a/server/handlers/tunnel.go
+++ b/server/handlers/tunnel.go
@@ -354,10 +354,6 @@ func wsTunnel(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			fmt.Println("----------------------------------")
-			fmt.Println("Data from client: ", string(data))
-			fmt.Println("--------------------------------")
-
 			if err = serviceProviderSoc.Write(ctx, websocket.MessageText, data); err != nil {
 				if isNormal(err) {
 					return

--- a/server/handlers/tunnel_test.go
+++ b/server/handlers/tunnel_test.go
@@ -46,6 +46,7 @@ const redirectUri = "redirect_uri"
 const username = "username"
 const password = "password"
 
+// FIXME @Osoro: test is incomplete
 func TestTunnel_WebSocketImpl(t *testing.T) {
 	// create the ws Server connection
 	wsMockClient := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +79,7 @@ func TestTunnel_WebSocketImpl(t *testing.T) {
 	req.Header.Add("X-Forwarded-Proto", "ws")
 	req.Header.Add("X-Forwarded-Host", url_parts[1])
 
-	// this bit here is to make the request a websocket request
+	// this bit here is to make the file descriptor a duplex connection
 	server, _ := net.Pipe()
 
 	rw := bufio.NewReadWriter(bufio.NewReader(server), bufio.NewWriter(server))


### PR DESCRIPTION
## Changes Introduced

- Added a health_check endpoint for checking the health of the forward_proxy and the reverse_proxy
- Added associated tests for the http handler with all scenarios

## Acceptance

- [x] Callable and info parsable from the interceptor-rs wasm for the retry bug
- [ ] Code reviewed by @interestIngc & @huzaifamk 
- [x] Does not modify existing code