### PR TITLE
implemented client x509 certificates processing

### DIFF
--- a/migrations/000009_certificate_uploads.down.sql
+++ b/migrations/000009_certificate_uploads.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS clients
+    DROP COLUMN x509_certificate_bytes;

--- a/migrations/000009_certificate_uploads.up.sql
+++ b/migrations/000009_certificate_uploads.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS clients
+    ADD COLUMN x509_certificate_bytes bytea;

--- a/server/assets-v1/templates/src/pages/client_portal/profile.html
+++ b/server/assets-v1/templates/src/pages/client_portal/profile.html
@@ -85,6 +85,7 @@
                                 <li class="font-bold md:text-xl text-sm text-black">Backend URI:</li>
                                 <li class="font-bold md:text-xl text-sm text-black">UUID:</li>
                                 <li class="font-bold md:text-xl text-sm text-black">Secret:</li>
+                                <li class="font-bold md:text-xl text-sm text-black">X509 Certificate:</li>
                             </ul>
                             <div class="col-span-2 flex flex-col space-y-2">
                                 <input class="bg-white border border-[#EADFD8] p-1 md:p-3 rounded-lg w-full font-medium"
@@ -136,6 +137,29 @@
                                             </path>
                                         </svg>
                                     </div>
+                                </div>
+
+                                <div class="flex items-center space-x-2">
+                                    <input readonly
+                                           class="bg-[#ECF4FD] border border-[#EADFD8] p-1 md:p-3 rounded-lg w-full font-medium"
+                                           placeholder="X509 Certificate"
+                                           :value="user.x509_certificate" />
+                                    <button value="Certificate" v-if="isCopied != user.x509_certificate" @click="copyToClipboard(user.x509_certificate)">
+                                        <svg fill="#000000" width="30px" height="30px" viewBox="0 0 16 16"
+                                             xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M14 12V2H4V0h12v12h-2zM0 4h12v12H0V4zm2 2v8h8V6H2z" fill-rule="evenodd" />
+                                        </svg>
+                                    </button>
+                                    <div v-if="isCopied == user.x509_certificate">
+                                        <svg fill="#000000" width="40px" height="40px" viewBox="0 0 32 32" version="1.1"
+                                             xmlns="http://www.w3.org/2000/svg">
+                                            <title>checked</title>
+                                            <path
+                                                    d="M26.5 27h-3c-0.276 0-0.5-0.224-0.5-0.5s0.224-0.5 0.5-0.5h2.5v-2.5c0-0.276 0.224-0.5 0.5-0.5 0.275 0 0.5 0.224 0.5 0.5v3c0 0.276-0.225 0.5-0.5 0.5zM26.5 21c-0.276 0-0.5-0.224-0.5-0.5v-3c0-0.276 0.224-0.5 0.5-0.5 0.275 0 0.5 0.224 0.5 0.5v3c0 0.276-0.225 0.5-0.5 0.5zM26.5 15c-0.276 0-0.5-0.224-0.5-0.5v-3c0-0.276 0.224-0.5 0.5-0.5 0.275 0 0.5 0.224 0.5 0.5v3c0 0.276-0.225 0.5-0.5 0.5zM26.5 9c-0.276 0-0.5-0.224-0.5-0.5v-2.5h-2.5c-0.276 0-0.5-0.224-0.5-0.5s0.224-0.5 0.5-0.5h3c0.275 0 0.5 0.224 0.5 0.5v3c0 0.276-0.225 0.5-0.5 0.5zM14.666 21.053c-0.184 0.185-0.483 0.185-0.668 0l-1.002-1.002c-0.002-0.003-0.001-0.007-0.003-0.009l-3.188-3.212c-0.185-0.184-0.185-0.483 0-0.668l1.002-1.003c0.185-0.185 0.484-0.185 0.669 0l2.86 2.881 6.014-6.013c0.184-0.185 0.483-0.185 0.668 0l1.002 1.003c0.186 0.185 0.186 0.484 0 0.669l-7.354 7.354zM20.5 6h-3c-0.276 0-0.5-0.224-0.5-0.5s0.224-0.5 0.5-0.5h3c0.275 0 0.5 0.224 0.5 0.5s-0.225 0.5-0.5 0.5zM14.5 6h-3c-0.276 0-0.5-0.224-0.5-0.5s0.224-0.5 0.5-0.5h3c0.275 0 0.5 0.224 0.5 0.5s-0.225 0.5-0.5 0.5zM8.5 27h-3c-0.276 0-0.5-0.224-0.5-0.5v-3c0-0.276 0.224-0.5 0.5-0.5s0.5 0.224 0.5 0.5v2.5h2.5c0.276 0 0.5 0.224 0.5 0.5s-0.224 0.5-0.5 0.5zM8.5 6h-2.5v2.5c0 0.276-0.224 0.5-0.5 0.5s-0.5-0.224-0.5-0.5v-3c0-0.276 0.224-0.5 0.5-0.5h3c0.276 0 0.5 0.224 0.5 0.5s-0.224 0.5-0.5 0.5zM5.5 11c0.276 0 0.5 0.224 0.5 0.5v3c0 0.276-0.224 0.5-0.5 0.5s-0.5-0.224-0.5-0.5v-3c0-0.276 0.224-0.5 0.5-0.5zM5.5 17c0.276 0 0.5 0.224 0.5 0.5v3c0 0.276-0.224 0.5-0.5 0.5s-0.5-0.224-0.5-0.5v-3c0-0.276 0.224-0.5 0.5-0.5zM11.5 26h3c0.275 0 0.5 0.224 0.5 0.5s-0.225 0.5-0.5 0.5h-3c-0.276 0-0.5-0.224-0.5-0.5s0.224-0.5 0.5-0.5zM17.5 26h3c0.275 0 0.5 0.224 0.5 0.5s-0.225 0.5-0.5 0.5h-3c-0.276 0-0.5-0.224-0.5-0.5s0.224-0.5 0.5-0.5z">
+                                            </path>
+                                        </svg>
+                                    </div>
+                                    <input type="file" accept=".crt,.pem" @change="handleX509CertificateUpload">
                                 </div>
                             </div>
                         </div>
@@ -233,6 +257,7 @@
         secret: "",
         name: "",
         redirect_uri: "",
+        x509_certificate: "",
     });
     const isCopied = ref("");
     const sidebarShow = ref(false);
@@ -258,6 +283,36 @@
     const unpaidAmountETH = ref("");
     const walletConnected = ref(false);
 
+    const handleX509CertificateUpload = async (event) => {
+        console.log("Certificate uploaded!");
+        const file = event.target.files[0];
+
+        const certificate = await file.text();
+        console.log(certificate);
+
+        const resp = await window.fetch(
+                "[[ .ProxyURL ]]/api/upload-certificate",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "Application/Json",
+                        Authorization: `Bearer ${token.value}`,
+                    },
+                    body: JSON.stringify({
+                        certificate: certificate,
+                    })
+                }
+        );
+
+        const responseBody = await resp.json();
+        if (resp.status === 201) {
+            user.value.x509_certificate = certificate;
+            showToastMessage("x509 certificate uploaded successfully", "success");
+        } else {
+            showToastMessage(responseBody.message, "error");
+        }
+    }
+
     const getUserDetails = async () => {
         try {
             const resp = await window.fetch(
@@ -270,8 +325,7 @@
                         },
                     }
             );
-            const data = await resp.json();
-            user.value = data;
+            user.value = await resp.json();
         } catch (error) {
             console.error(error);
         }
@@ -443,7 +497,7 @@
                     }
                 })
 
-                getUserDetails();
+                await getUserDetails();
             });
 
             return {
@@ -464,6 +518,7 @@
                 cancelModel,
                 payTraffic,
                 payWithCrypto,
+                handleX509CertificateUpload,
             };
         },
     });

--- a/server/cmd/app/main.go
+++ b/server/cmd/app/main.go
@@ -156,8 +156,6 @@ func main() {
 		ticker := time.NewTicker(updateInterval)
 
 		for currTime := range ticker.C {
-			//ctx, cancel := context.WithTimeout(context.Background(), updateInterval)
-
 			err := statisticsUpdater.Update(context.Background(), currTime)
 			if err != nil {
 				log.Println(err)
@@ -231,6 +229,10 @@ func Server(resourceService interfaces.IService, oauthService *oauthSvc.Service)
 				authorizationHandler.OAuthToken(w, r)
 			case path == "/api/user":
 				handlers.UserInfo(w, r)
+			case path == "/sp-pub-key":
+				handlers.GetSPPubKey(w, r)
+			case path == "/api/upload-certificate":
+				handlers.UploadSPCertificate(w, r)
 			case strings.HasPrefix(path, "/assets-v1"):
 				http.StripPrefix("/assets-v1", http.FileServer(http.Dir("./assets-v1"))).ServeHTTP(w, r)
 

--- a/server/entities/dto.go
+++ b/server/entities/dto.go
@@ -1,0 +1,9 @@
+package entities
+
+type X509CertificateRequest struct {
+	Certificate string `json:"certificate" validate:"required"`
+}
+
+type X509CertificateResponse struct {
+	X509Certificate string `json:"x509_certificate"`
+}

--- a/server/handlers/sp_certificates.go
+++ b/server/handlers/sp_certificates.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"globe-and-citizen/layer8/server/entities"
+	svc "globe-and-citizen/layer8/server/internals/service"
+	"globe-and-citizen/layer8/server/resource_server/utils"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func UploadSPCertificate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		errorMessage := fmt.Sprintf("Invalid http method, expected POST, actual: %s", r.Method)
+
+		utils.HandleError(w, http.StatusMethodNotAllowed, errorMessage, fmt.Errorf(errorMessage))
+		return
+	}
+
+	token := r.Header.Get("Authorization")
+	if token == "" {
+		utils.HandleError(
+			w,
+			http.StatusUnauthorized,
+			"authorization token is empty",
+			fmt.Errorf("token is invalid"),
+		)
+		return
+	}
+	token = token[7:]
+
+	clientClaims, err := utils.ValidateClientToken(token)
+	if err != nil {
+		utils.HandleError(
+			w,
+			http.StatusUnauthorized,
+			"failed to verify client auth token",
+			err,
+		)
+		return
+	}
+
+	req, err := utils.DecodeJsonFromRequest[entities.X509CertificateRequest](w, r.Body)
+	if err != nil {
+		return
+	}
+
+	service := r.Context().Value("Oauthservice").(svc.ServiceInterface)
+
+	err = service.SaveX509Certificate(clientClaims.ClientID, req.Certificate)
+	if err != nil {
+		utils.HandleError(w, http.StatusInternalServerError, "failed to save the SP x.509 certificate", err)
+		return
+	}
+
+	response := utils.BuildResponseWithNoBody(
+		w,
+		http.StatusCreated,
+		"x.509 certificate was saved successfully",
+	)
+
+	if err := json.NewEncoder(w).Encode(&response); err != nil {
+		utils.HandleError(w, http.StatusInternalServerError, "failed to encode the response", err)
+	}
+}
+
+// GetSPPubKey handles requests to get the public key for the service provider
+func GetSPPubKey(w http.ResponseWriter, r *http.Request) {
+	service := r.Context().Value("Oauthservice").(svc.ServiceInterface)
+	switch r.Method {
+	case "GET":
+		backendURL := r.URL.Query().Get("backend_url")
+		if backendURL == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error": "missing backend_url parameter"}`))
+			return
+		}
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "missing token"}`))
+			return
+		}
+		// Uncomment the following lines to generate a token for testing purposes, to be removed in production
+		// token, err := utilities.GenerateStandardToken("ThisIsASecret")
+		// if err != nil {
+		// 	log.Println(err)
+		// 	w.WriteHeader(http.StatusInternalServerError)
+		// 	w.Write([]byte(`{"error": "internal server error"}`))
+		// 	return
+		// }
+		isValid, err := service.VerifyToken(token)
+		if err != nil {
+			log.Println(err)
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "invalid token"}`))
+			return
+		}
+		if !isValid {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "invalid token"}`))
+			return
+		}
+		client, err := service.CheckClient(backendURL)
+		if err != nil {
+			log.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error": "internal server error", "registered": false}`))
+			return
+		}
+
+		response := entities.X509CertificateResponse{
+			X509Certificate: string(client.X509CertificateBytes),
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			w.Write([]byte(`{"error": "internal server error", "registered": false}`))
+		}
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte(`{"error": "method not allowed"}`))
+		return
+	}
+}

--- a/server/handlers/sp_certificates_test.go
+++ b/server/handlers/sp_certificates_test.go
@@ -1,0 +1,396 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	utilities "github.com/globe-and-citizen/layer8-utils"
+	"github.com/golang-jwt/jwt/v4"
+	"globe-and-citizen/layer8/server/entities"
+	"globe-and-citizen/layer8/server/internals/repository"
+	svc "globe-and-citizen/layer8/server/internals/service"
+	"globe-and-citizen/layer8/server/models"
+	"globe-and-citizen/layer8/server/resource_server/utils"
+	"golang.org/x/oauth2"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	Ctl "globe-and-citizen/layer8/server/handlers"
+
+	"github.com/stretchr/testify/assert"
+	resourceModels "globe-and-citizen/layer8/server/resource_server/models"
+)
+
+var mockService = &svc.Service{
+	Repo: &repository.PostgresRepository{},
+}
+
+type MockService struct {
+	getUserByToken           func(token string) (*models.User, error)
+	loginUser                func(username, password string) (map[string]interface{}, error)
+	generateAuthorizationURL func(config *oauth2.Config, userID int64, headerMap map[string]string) (*entities.AuthURL, error)
+	exchangeCodeForToken     func(config *oauth2.Config, code string) (*oauth2.Token, error)
+	accessResourcesWithToken func(token string) (map[string]interface{}, error)
+	getClient                func(id string) (*models.Client, error)
+	verifyToken              func(token string) (isvalid bool, err error)
+	checkClient              func(backendURL string) (*models.Client, error)
+	saveX509Certificate      func(clientID string, certificate string) error
+	addTestClient            func() (*models.Client, error)
+}
+
+func (m MockService) GetUserByToken(token string) (*models.User, error) {
+	return m.getUserByToken(token)
+}
+
+func (m MockService) LoginUser(username, password string) (map[string]interface{}, error) {
+	return m.loginUser(username, password)
+}
+
+func (m MockService) GenerateAuthorizationURL(config *oauth2.Config, userID int64, headerMap map[string]string) (*entities.AuthURL, error) {
+	return m.generateAuthorizationURL(config, userID, headerMap)
+}
+
+func (m MockService) ExchangeCodeForToken(config *oauth2.Config, code string) (*oauth2.Token, error) {
+	return m.exchangeCodeForToken(config, code)
+}
+
+func (m MockService) AccessResourcesWithToken(token string) (map[string]interface{}, error) {
+	return m.accessResourcesWithToken(token)
+}
+
+func (m MockService) GetClient(id string) (*models.Client, error) {
+	return m.getClient(id)
+}
+
+func (m MockService) VerifyToken(token string) (isvalid bool, err error) {
+	return m.verifyToken(token)
+}
+
+func (m MockService) CheckClient(backendURL string) (*models.Client, error) {
+	return m.checkClient(backendURL)
+}
+
+func (m MockService) SaveX509Certificate(clientID string, certificate string) error {
+	return m.saveX509Certificate(clientID, certificate)
+}
+
+func (m MockService) AddTestClient() (*models.Client, error) {
+	return m.addTestClient()
+}
+
+const clientId = "clientID"
+const backendUrl = "backend URL"
+const certificate = "x509 certificate"
+
+const jwtSecretKey = "JwtSecretkey"
+
+func Test_GetSPPubKeyHandler_InvalidHttpRequestMethod(t *testing.T) {
+	context := context.WithValue(context.Background(), "Oauthservice", mockService)
+	req, err := http.NewRequest("POST", "/sp-pub-key", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = req.WithContext(context)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.GetSPPubKey(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	assert.Equal(t, `{"error": "method not allowed"}`, rr.Body.String())
+}
+
+func Test_GetSPPubKeyHandler_MissingBackendURL(t *testing.T) {
+	context := context.WithValue(context.Background(), "Oauthservice", mockService)
+	req, err := http.NewRequest("GET", "/sp-pub-key?backend_url=", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = req.WithContext(context)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.GetSPPubKey(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Equal(t, `{"error": "missing backend_url parameter"}`, rr.Body.String())
+}
+
+func Test_GetSPPubKeyHandler_MissingToken(t *testing.T) {
+	context := context.WithValue(context.Background(), "Oauthservice", mockService)
+	req, err := http.NewRequest("GET", "/sp-pub-key?backend_url=http://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = req.WithContext(context)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.GetSPPubKey(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, `{"error": "missing token"}`, rr.Body.String())
+}
+
+func Test_GetSPPubKeyHandler_InvalidToken(t *testing.T) {
+	context := context.WithValue(context.Background(), "Oauthservice", mockService)
+	req, err := http.NewRequest("GET", "/sp-pub-key?backend_url=http://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer invalid_token")
+	req = req.WithContext(context)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.GetSPPubKey(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, `{"error": "invalid token"}`, rr.Body.String())
+}
+
+func Test_GetSPPubKeyHandler_CertificateServedSuccessfully(t *testing.T) {
+	mockService := MockService{
+		checkClient: func(backendURL string) (*models.Client, error) {
+			if backendURL != backendUrl {
+				t.Fatalf("invalid backend url, expected: %s, got: %s", backendUrl, backendURL)
+			}
+
+			return &models.Client{
+				ID:                   clientId,
+				BackendURI:           backendUrl,
+				X509CertificateBytes: []byte(certificate),
+			}, nil
+		},
+		verifyToken: func(token string) (isvalid bool, err error) {
+			return true, nil
+		},
+	}
+
+	os.Setenv("JWT_SECRET_KEY", jwtSecretKey)
+	jwtToken, _ := utilities.GenerateStandardToken(jwtSecretKey)
+
+	ctx := context.WithValue(context.Background(), "Oauthservice", mockService)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/sp-pub-key?backend_url=%s", backendUrl), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	Ctl.GetSPPubKey(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response entities.X509CertificateResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response body: %e", err)
+	}
+
+	assert.Equal(t, certificate, response.X509Certificate)
+}
+
+func TestUploadSPCertificate_InvalidHTTPMethod(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "/api/upload-certificate", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", MockService{}))
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestUploadSPCertificate_AuthorizationTokenIsMissing(t *testing.T) {
+	request := []byte(`{"certificate": "x509 certificate"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/upload-certificate", bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", MockService{}))
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestUploadSPCertificate_InvalidAuthorizationToken(t *testing.T) {
+	request := []byte(`{"certificate": "x509 certificate"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/upload-certificate", bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", MockService{}))
+	req.Header.Set("Authorization", "Bearer invalid token")
+
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestUploadSPCertificate_InvalidRequestSchema(t *testing.T) {
+	request := []byte(`{somethingelse}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/upload-certificate", bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", MockService{}))
+
+	os.Setenv("JWT_SECRET_KEY", jwtSecretKey)
+	req.Header.Set("Authorization", "Bearer "+generateJwtToken())
+
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBodyForResponse(t, rr)
+
+	assert.False(t, response.IsSuccess)
+	assert.Equal(t, "Request malformed: error while parsing json", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestUploadSPCertificate_RequiredRequestParameterIsMissing(t *testing.T) {
+	os.Setenv("JWT_SECRET_KEY", jwtSecretKey)
+
+	request := []byte(`{"something_else": "some_value"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/upload-certificate", bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", MockService{}))
+	req.Header.Set("Authorization", "Bearer "+generateJwtToken())
+
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	response := decodeResponseBodyForResponse(t, rr)
+
+	assert.False(t, response.IsSuccess)
+	assert.Equal(t, "Input json is invalid", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestUploadSPCertificate_FailedToSaveClientCertificate(t *testing.T) {
+	os.Setenv("JWT_SECRET_KEY", jwtSecretKey)
+
+	request := []byte(`{"certificate": "x509 certificate"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/upload-certificate", bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	service := MockService{
+		saveX509Certificate: func(clientID string, x509Certificate string) error {
+			if clientID != clientId {
+				t.Fatalf("Invalid clientID, expected: %s, got: %s", clientId, clientID)
+			}
+			if x509Certificate != certificate {
+				t.Fatalf("Invalid certificate, expected: %s, got: %s", certificate, x509Certificate)
+			}
+			return fmt.Errorf("failed to save certificate")
+		},
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", service))
+	req.Header.Set("Authorization", "Bearer "+generateJwtToken())
+
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	response := decodeResponseBodyForResponse(t, rr)
+
+	assert.False(t, response.IsSuccess)
+	assert.Equal(t, "failed to save the SP x.509 certificate", response.Message)
+	assert.NotNil(t, response.Error)
+}
+
+func TestUploadSPCertificate_ClientCertificateSavedSuccessfully(t *testing.T) {
+	os.Setenv("JWT_SECRET_KEY", jwtSecretKey)
+
+	request := []byte(`{"certificate": "x509 certificate"}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/upload-certificate", bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	service := MockService{
+		saveX509Certificate: func(clientID string, x509Certificate string) error {
+			if clientID != clientId {
+				t.Fatalf("Invalid clientID, expected: %s, got: %s", clientId, clientID)
+			}
+			if x509Certificate != certificate {
+				t.Fatalf("Invalid certificate, expected: %s, got: %s", certificate, x509Certificate)
+			}
+			return nil
+		},
+	}
+
+	req = req.WithContext(context.WithValue(context.Background(), "Oauthservice", service))
+	req.Header.Set("Authorization", "Bearer "+generateJwtToken())
+
+	rr := httptest.NewRecorder()
+
+	Ctl.UploadSPCertificate(rr, req)
+
+	assert.Equal(t, http.StatusCreated, rr.Code)
+
+	response := decodeResponseBodyForResponse(t, rr)
+
+	assert.True(t, response.IsSuccess)
+	assert.Equal(t, "x.509 certificate was saved successfully", response.Message)
+	assert.Nil(t, response.Error)
+}
+
+func generateJwtToken() string {
+	claims := &resourceModels.ClientClaims{
+		UserName: "username",
+		ClientID: clientId,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(60 * time.Minute)),
+			Issuer:    "GlobeAndCitizen",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte(jwtSecretKey))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return tokenString
+}
+
+func decodeResponseBodyForResponse(t *testing.T, rr *httptest.ResponseRecorder) utils.Response {
+	var response utils.Response
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	return response
+}

--- a/server/internals/repository/main.go
+++ b/server/internals/repository/main.go
@@ -26,6 +26,11 @@ type Repository interface {
 	// Get a client by ID.
 	GetClient(id string) (*models.Client, error)
 
+	GetClientByURL(url string) (*models.Client, error)
+
+	// SaveX509Certificate saves the x509 certificate per client
+	SaveX509Certificate(clientID string, certificate string) error
+
 	// SetTTL sets the value for the given key with a short TTL.
 	SetTTL(key string, value []byte, ttl time.Duration) error
 

--- a/server/internals/repository/repository.go
+++ b/server/internals/repository/repository.go
@@ -87,6 +87,22 @@ func (r *PostgresRepository) GetClient(id string) (*models.Client, error) {
 	return &client, nil
 }
 
+func (r *PostgresRepository) GetClientByURL(url string) (*models.Client, error) {
+	var client models.Client
+	err := r.db.Where("backend_uri = ?", url).First(&client).Error
+	if err != nil {
+		return &models.Client{}, err
+	}
+	return &client, nil
+}
+
+func (r *PostgresRepository) SaveX509Certificate(clientID string, certificate string) error {
+	return r.db.Model(&models.Client{}).
+		Where("id = ?", clientID).
+		Update("x509_certificate_bytes", certificate).
+		Error
+}
+
 // SetTTL sets the key to hold the value for a limited time
 func (r *PostgresRepository) SetTTL(key string, value []byte, ttl time.Duration) error {
 	r.storage[key] = value

--- a/server/internals/service/service.go
+++ b/server/internals/service/service.go
@@ -26,6 +26,9 @@ type ServiceInterface interface {
 	ExchangeCodeForToken(config *oauth2.Config, code string) (*oauth2.Token, error)
 	AccessResourcesWithToken(token string) (map[string]interface{}, error)
 	GetClient(id string) (*models.Client, error)
+	VerifyToken(token string) (isvalid bool, err error)
+	CheckClient(backendURL string) (*models.Client, error)
+	SaveX509Certificate(clientID string, certificate string) error
 	AddTestClient() (*models.Client, error)
 }
 
@@ -218,6 +221,19 @@ func (u *Service) AccessResourcesWithToken(token string) (map[string]interface{}
 	return resources, nil
 }
 
+func (u *Service) VerifyToken(token string) (isvalid bool, err error) {
+	// verify token
+	jwtClaims, err := utilities.VerifyStandardToken(token, os.Getenv("JWT_SECRET_KEY"))
+	if err != nil {
+		return false, err
+	}
+	// check if the token is expired
+	if jwtClaims.ExpiresAt < time.Now().Unix() {
+		return false, fmt.Errorf("token is expired")
+	}
+	return true, nil
+}
+
 func (u *Service) GetClient(id string) (*models.Client, error) {
 	client, err := u.Repo.GetClient(fmt.Sprintf("client:%s", id))
 	if err != nil {
@@ -225,6 +241,21 @@ func (u *Service) GetClient(id string) (*models.Client, error) {
 	}
 
 	return client, nil
+}
+
+func (u *Service) CheckClient(backendURL string) (*models.Client, error) {
+	client, err := u.Repo.GetClientByURL(backendURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not get client: %v", err)
+	}
+	if client == nil {
+		return nil, fmt.Errorf("client not found")
+	}
+	return client, nil
+}
+
+func (u *Service) SaveX509Certificate(clientID string, certificate string) error {
+	return u.Repo.SaveX509Certificate(clientID, certificate)
 }
 
 // this is only be used for testing purposes

--- a/server/internals/service/service_test.go
+++ b/server/internals/service/service_test.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"globe-and-citizen/layer8/server/models"
+	"os"
+	"testing"
+	"time"
+
+	utilities "github.com/globe-and-citizen/layer8-utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockRepository is a mock implementation of the Repository interface
+type MockRepository struct {
+	mock.Mock
+}
+
+const clientID = "clientID"
+const certificate = "certificate"
+
+func (m *MockRepository) GetClient(key string) (*models.Client, error) {
+	args := m.Called(key)
+	return args.Get(0).(*models.Client), args.Error(1)
+}
+
+func (m *MockRepository) GetClientByURL(backendURL string) (*models.Client, error) {
+	args := m.Called(backendURL)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Client), args.Error(1)
+}
+
+// Implement other required repository methods with empty implementations
+func (m *MockRepository) SetClient(client *models.Client) error                           { return nil }
+func (m *MockRepository) GetUserByID(id int64) (*models.User, error)                      { return nil, nil }
+func (m *MockRepository) LoginUserPrecheck(username string) (string, error)               { return "", nil }
+func (m *MockRepository) GetUser(username string) (*models.User, error)                   { return nil, nil }
+func (m *MockRepository) SetTTL(key string, value []byte, expiration time.Duration) error { return nil }
+func (m *MockRepository) GetTTL(key string) ([]byte, error)                               { return nil, nil }
+func (m *MockRepository) GetUserMetadata(userID int64, key string) (*models.UserMetadata, error) {
+	return &models.UserMetadata{}, nil
+}
+
+func (m *MockRepository) SaveX509Certificate(clientID string, certificate string) error {
+	args := m.Called(clientID, certificate)
+	return args.Error(0)
+}
+
+func TestService_VerifyToken(t *testing.T) {
+	// Set up JWT secret for testing
+	os.Setenv("JWT_SECRET_KEY", "test-secret-key")
+	defer os.Unsetenv("JWT_SECRET_KEY")
+
+	// Generate test tokens first
+	validToken, err := utilities.GenerateStandardToken("test-secret-key")
+	if err != nil {
+		t.Fatalf("Failed to generate valid test token: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		token       string
+		wantIsValid bool
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name:        "valid token",
+			token:       validToken,
+			wantIsValid: true,
+			wantErr:     false,
+		},
+		{
+			name:        "invalid token",
+			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.l7W7V46W3NlY9tY80y660y0z022b2960201920200222",
+			wantIsValid: false,
+			wantErr:     true,
+			errMsg:      "signature is invalid",
+		},
+	}
+
+	// Initialize service with mock repository
+	mockRepo := new(MockRepository)
+	service := NewService(mockRepo)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isValid, err := service.VerifyToken(tt.token)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantIsValid, isValid)
+		})
+	}
+}
+
+func TestService_CheckClient(t *testing.T) {
+	tests := []struct {
+		name       string
+		backendURL string
+		wantClient *models.Client
+		wantErr    bool
+		errMsg     string
+		mockSetup  func(*MockRepository)
+	}{
+		{
+			name:       "client found",
+			backendURL: "http://valid-client.com",
+			wantClient: &models.Client{
+				ID:         "test-client",
+				Secret:     "test-secret",
+				Name:       "Test Client",
+				BackendURI: "http://valid-client.com",
+			},
+			wantErr: false,
+			mockSetup: func(m *MockRepository) {
+				m.On("GetClientByURL", "http://valid-client.com").
+					Return(&models.Client{
+						ID:         "test-client",
+						Secret:     "test-secret",
+						Name:       "Test Client",
+						BackendURI: "http://valid-client.com",
+					}, nil)
+			},
+		},
+		{
+			name:       "client not found",
+			backendURL: "http://invalid-client.com",
+			wantClient: nil,
+			wantErr:    true,
+			errMsg:     "client not found",
+			mockSetup: func(m *MockRepository) {
+				m.On("GetClientByURL", "http://invalid-client.com").
+					Return(nil, errors.New("client not found"))
+			},
+		},
+		{
+			name:       "repository error",
+			backendURL: "http://error-client.com",
+			wantClient: nil,
+			wantErr:    true,
+			errMsg:     "could not get client",
+			mockSetup: func(m *MockRepository) {
+				m.On("GetClientByURL", "http://error-client.com").
+					Return(nil, errors.New("database error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := new(MockRepository)
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockRepo)
+			}
+
+			service := NewService(mockRepo)
+			client, err := service.CheckClient(tt.backendURL)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantClient, client)
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSaveX509Certificate_RepositoryFailedToSaveCertificate(t *testing.T) {
+	mockRepo := &MockRepository{}
+	mockRepo.On(
+		"SaveX509Certificate", clientID, certificate,
+	).Return(
+		fmt.Errorf("repository error"),
+	)
+
+	service := NewService(mockRepo)
+
+	err := service.SaveX509Certificate(clientID, certificate)
+
+	assert.NotNil(t, err)
+}
+
+func TestSaveX509Certificate_Success(t *testing.T) {
+	mockRepo := &MockRepository{}
+	mockRepo.On(
+		"SaveX509Certificate", clientID, certificate,
+	).Return(nil)
+
+	service := NewService(mockRepo)
+
+	err := service.SaveX509Certificate(clientID, certificate)
+
+	assert.Nil(t, err)
+}

--- a/server/models/client.go
+++ b/server/models/client.go
@@ -1,14 +1,15 @@
 package models
 
 type Client struct {
-	ID          string `json:"id"`
-	Secret      string `json:"secret"`
-	Name        string `json:"name"`
-	RedirectURI string `json:"redirect_uri"`
-	BackendURI  string `json:"backend_uri"`
-	Username    string `json:"username"`
-	Password    string `json:"password"`
-	Salt        string `json:"salt"`
+	ID                   string `gorm:"column:id; not null" json:"id"`
+	Secret               string `gorm:"column:secret" json:"secret"`
+	Name                 string `gorm:"column:name" json:"name"`
+	RedirectURI          string `gorm:"column:redirect_uri" json:"redirect_uri"`
+	BackendURI           string `gorm:"column:backend_uri" json:"backend_uri"`
+	Username             string `gorm:"column:username; unique; not null" json:"username"`
+	Password             string `gorm:"column:password; not null" json:"password"`
+	Salt                 string `gorm:"column:salt; not null" json:"salt"`
+	X509CertificateBytes []byte `gorm:"column:x509_certificate_bytes" json:"x509_certificate_bytes"`
 }
 
 func CreateClient(id, secret, name, redirect_uri string) Client {

--- a/server/resource_server/models/client.go
+++ b/server/resource_server/models/client.go
@@ -1,17 +1,18 @@
 package models
 
 type Client struct {
-	ID             string `gorm:"column:id; not null" json:"id"`
-	Secret         string `gorm:"column:secret" json:"secret"`
-	Name           string `gorm:"column:name" json:"name"`
-	RedirectURI    string `gorm:"column:redirect_uri" json:"redirect_uri"`
-	BackendURI     string `gorm:"column:backend_uri" json:"backend_uri"`
-	Username       string `gorm:"column:username; unique; not null" json:"username"`
-	Password       string `gorm:"column:password; not null" json:"password"`
-	Salt           string `gorm:"column:salt; not null" json:"salt"`
-	IterationCount int    `gorm:"column:iteration_count;" json:"iteration_count"`
-	ServerKey      string `gorm:"column:server_key;" json:"server_key"`
-	StoredKey      string `gorm:"column:stored_key;" json:"stored_key"`
+	ID              string `gorm:"column:id; not null" json:"id"`
+	Secret          string `gorm:"column:secret" json:"secret"`
+	Name            string `gorm:"column:name" json:"name"`
+	RedirectURI     string `gorm:"column:redirect_uri" json:"redirect_uri"`
+	BackendURI      string `gorm:"column:backend_uri" json:"backend_uri"`
+	Username        string `gorm:"column:username; unique; not null" json:"username"`
+	Password        string `gorm:"column:password; not null" json:"password"`
+	Salt            string `gorm:"column:salt; not null" json:"salt"`
+	IterationCount  int    `gorm:"column:iteration_count;" json:"iteration_count"`
+	ServerKey       string `gorm:"column:server_key;" json:"server_key"`
+	StoredKey       string `gorm:"column:stored_key;" json:"stored_key"`
+	X509Certificate string `gorm:"column:x509_certificate_bytes" json:"x509_certificate_bytes"`
 }
 
 func (Client) TableName() string {

--- a/server/resource_server/models/response.go
+++ b/server/resource_server/models/response.go
@@ -35,11 +35,12 @@ type ProfileResponseOutput struct {
 }
 
 type ClientResponseOutput struct {
-	ID          string `json:"id"`
-	Secret      string `json:"secret"`
-	Name        string `json:"name"`
-	RedirectURI string `json:"redirect_uri"`
-	BackendURI  string `json:"backend_uri"`
+	ID              string `json:"id"`
+	Secret          string `json:"secret"`
+	Name            string `json:"name"`
+	RedirectURI     string `json:"redirect_uri"`
+	BackendURI      string `json:"backend_uri"`
+	X509Certificate string `json:"x509_certificate"`
 }
 
 type RegisterUserPrecheckResponseOutput struct {

--- a/server/resource_server/repository/repository.go
+++ b/server/resource_server/repository/repository.go
@@ -235,9 +235,9 @@ func (r *Repository) ProfileUser(userID uint) (models.User, []models.UserMetadat
 	return user, userMetadata, nil
 }
 
-func (r *Repository) ProfileClient(userID string) (models.Client, error) {
+func (r *Repository) ProfileClient(username string) (models.Client, error) {
 	var client models.Client
-	if err := r.connection.Where("username = ?", userID).First(&client).Error; err != nil {
+	if err := r.connection.Where("username = ?", username).First(&client).Error; err != nil {
 		return models.Client{}, err
 	}
 	return client, nil

--- a/server/resource_server/repository/repository_test.go
+++ b/server/resource_server/repository/repository_test.go
@@ -226,10 +226,10 @@ func TestRegisterClient_InsertQueryFailed(t *testing.T) {
 
 	mock.ExpectExec(
 		regexp.QuoteMeta(
-			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key","x509_certificate_bytes") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		),
 	).WithArgs(
-		clientId, clientSecret, clientName, redirectUri, backendUri, clientUsername, clientPassword, clientSalt, 0, "", "",
+		clientId, clientSecret, clientName, redirectUri, backendUri, clientUsername, clientPassword, clientSalt, 0, "", "", "",
 	).WillReturnError(
 		fmt.Errorf("failed to insert client %s", clientId),
 	)
@@ -260,10 +260,10 @@ func TestRegisterClient_Success(t *testing.T) {
 
 	mock.ExpectExec(
 		regexp.QuoteMeta(
-			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key","x509_certificate_bytes") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		),
 	).WithArgs(
-		clientId, clientSecret, clientName, redirectUri, backendUri, clientUsername, clientPassword, clientSalt, 0, "", "",
+		clientId, clientSecret, clientName, redirectUri, backendUri, clientUsername, clientPassword, clientSalt, 0, "", "", sqlmock.AnyArg(),
 	).WillReturnResult(
 		sqlmock.NewResult(1, 1),
 	)
@@ -1581,10 +1581,10 @@ func TestRegisterPrecheckClient_Success(t *testing.T) {
 
 	mock.ExpectExec(
 		regexp.QuoteMeta(
-			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key","x509_certificate_bytes") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		),
 	).WithArgs(
-		"", "", "", "", "", clientUsername, "", clientSalt, clientIterationCount, sqlmock.AnyArg(), sqlmock.AnyArg(),
+		"", "", "", "", "", clientUsername, "", clientSalt, clientIterationCount, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 	).WillReturnResult(
 		sqlmock.NewResult(1, 1),
 	)
@@ -1609,10 +1609,10 @@ func TestRegisterPrecheckClient_RepositoryError(t *testing.T) {
 
 	mock.ExpectExec(
 		regexp.QuoteMeta(
-			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+			`INSERT INTO "clients" ("id","secret","name","redirect_uri","backend_uri","username","password","salt","iteration_count","server_key","stored_key","x509_certificate_bytes") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		),
 	).WithArgs(
-		"", "", "", "", "", clientUsername, "", clientSalt, clientIterationCount, sqlmock.AnyArg(), sqlmock.AnyArg(),
+		"", "", "", "", "", clientUsername, "", clientSalt, clientIterationCount, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 	).WillReturnError(fmt.Errorf("failed to create client"))
 
 	mock.ExpectRollback()

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -92,11 +92,12 @@ func (s *service) GetClientData(clientName string) (models.ClientResponseOutput,
 		return models.ClientResponseOutput{}, err
 	}
 	clientModel := models.ClientResponseOutput{
-		ID:          clientData.ID,
-		Secret:      clientData.Secret,
-		Name:        clientData.Name,
-		RedirectURI: clientData.RedirectURI,
-		BackendURI:  clientData.BackendURI,
+		ID:              clientData.ID,
+		Secret:          clientData.Secret,
+		Name:            clientData.Name,
+		RedirectURI:     clientData.RedirectURI,
+		BackendURI:      clientData.BackendURI,
+		X509Certificate: clientData.X509Certificate,
 	}
 	return clientModel, nil
 }
@@ -107,11 +108,12 @@ func (s *service) GetClientDataByBackendURL(backendURL string) (models.ClientRes
 		return models.ClientResponseOutput{}, err
 	}
 	clientModel := models.ClientResponseOutput{
-		ID:          clientData.ID,
-		Secret:      clientData.Secret,
-		Name:        clientData.Name,
-		RedirectURI: clientData.RedirectURI,
-		BackendURI:  clientData.BackendURI,
+		ID:              clientData.ID,
+		Secret:          clientData.Secret,
+		Name:            clientData.Name,
+		RedirectURI:     clientData.RedirectURI,
+		BackendURI:      clientData.BackendURI,
+		X509Certificate: clientData.X509Certificate,
 	}
 	return clientModel, nil
 }
@@ -328,17 +330,18 @@ func (s *service) ProfileUser(userID uint) (models.ProfileResponseOutput, error)
 	return profileResp, nil
 }
 
-func (s *service) ProfileClient(userName string) (models.ClientResponseOutput, error) {
-	clientData, err := s.repository.ProfileClient(userName)
+func (s *service) ProfileClient(username string) (models.ClientResponseOutput, error) {
+	clientData, err := s.repository.ProfileClient(username)
 	if err != nil {
 		return models.ClientResponseOutput{}, err
 	}
 	clientModel := models.ClientResponseOutput{
-		ID:          clientData.ID,
-		Secret:      clientData.Secret,
-		Name:        clientData.Name,
-		RedirectURI: clientData.RedirectURI,
-		BackendURI:  clientData.BackendURI,
+		ID:              clientData.ID,
+		Secret:          clientData.Secret,
+		Name:            clientData.Name,
+		RedirectURI:     clientData.RedirectURI,
+		BackendURI:      clientData.BackendURI,
+		X509Certificate: clientData.X509Certificate,
 	}
 	return clientModel, nil
 }

--- a/server/utils/mocks/internal_service_mock.go
+++ b/server/utils/mocks/internal_service_mock.go
@@ -66,6 +66,21 @@ func (mr *MockServiceInterfaceMockRecorder) AddTestClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTestClient", reflect.TypeOf((*MockServiceInterface)(nil).AddTestClient))
 }
 
+// CheckClient mocks base method.
+func (m *MockServiceInterface) CheckClient(backendURL string) (*models.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckClient", backendURL)
+	ret0, _ := ret[0].(*models.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckClient indicates an expected call of CheckClient.
+func (mr *MockServiceInterfaceMockRecorder) CheckClient(backendURL interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckClient", reflect.TypeOf((*MockServiceInterface)(nil).CheckClient), backendURL)
+}
+
 // ExchangeCodeForToken mocks base method.
 func (m *MockServiceInterface) ExchangeCodeForToken(config *oauth2.Config, code string) (*oauth2.Token, error) {
 	m.ctrl.T.Helper()
@@ -139,4 +154,33 @@ func (m *MockServiceInterface) LoginUser(username, password string) (map[string]
 func (mr *MockServiceInterfaceMockRecorder) LoginUser(username, password interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginUser", reflect.TypeOf((*MockServiceInterface)(nil).LoginUser), username, password)
+}
+
+// SaveX509Certificate mocks base method.
+func (m *MockServiceInterface) SaveX509Certificate(clientID, certificate string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveX509Certificate", clientID, certificate)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveX509Certificate indicates an expected call of SaveX509Certificate.
+func (mr *MockServiceInterfaceMockRecorder) SaveX509Certificate(clientID, certificate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveX509Certificate", reflect.TypeOf((*MockServiceInterface)(nil).SaveX509Certificate), clientID, certificate)
+}
+
+// VerifyToken mocks base method.
+func (m *MockServiceInterface) VerifyToken(token string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyToken", token)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyToken indicates an expected call of VerifyToken.
+func (mr *MockServiceInterfaceMockRecorder) VerifyToken(token interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyToken", reflect.TypeOf((*MockServiceInterface)(nil).VerifyToken), token)
 }


### PR DESCRIPTION
## Description

- Backend:
   - Implemented the new endpoint `/api/upload-certificate` which saves x509 certificate into the db per given client
      - Validates the client JWT token and extracts the client id out of it
      - Updates table `clients` to persist the client x509 certificate
   - Modified endpoint `/sp-pub-key` to return the client's x509 certificate
 
- Frontend:
   - Implemented the input field on the client portal to select & upload x509 certificate from Desktop

## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [x] Created a new user on the Layer8 Portal

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [x] Login as 'tester', '1234'
- [x] Choose login with layer8 
- [x] Logging in with the newly registered credentials from Section 1 succeeds in popup
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Choose poems 1 - 3 works correctly 

### SECTION 3: IMSHARER (http://localhost:5174/)
- [x] Uploads an image works
- [x] Reload leads to instant reload (demonstrating proper caching)


