### PR TITLE
Fixes to phone number verifications

### DIFF
--- a/server/resource_server/controller/controller.go
+++ b/server/resource_server/controller/controller.go
@@ -828,7 +828,11 @@ func VerifyPhoneNumberViaTelegramBotHandler(w http.ResponseWriter, r *http.Reque
 	var offset int64 = 0
 	var telegramUserID int64 = 0
 
-	for {
+	for i := 0; i < 500; i++ {
+		if i > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+
 		updates, err := newService.RefreshTelegramMessages(baseURL, offset)
 		if err != nil {
 			log.Printf("failed to refresh messages from Telegram: %v\n", err)
@@ -900,7 +904,11 @@ func VerifyPhoneNumberViaTelegramBotHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	for {
+	for i := 0; i < 500; i++ {
+		if i > 0 {
+			time.Sleep(400 * time.Millisecond)
+		}
+
 		updates, err := newService.RefreshTelegramMessages(baseURL, offset)
 		if err != nil {
 			log.Printf("failed to refresh messages from Telegram: %v\n", err)
@@ -927,7 +935,6 @@ func VerifyPhoneNumberViaTelegramBotHandler(w http.ResponseWriter, r *http.Reque
 			}
 
 			phoneNumber := strings.TrimSpace(msg.Contact.PhoneNumber)
-			fmt.Println(phoneNumber)
 
 			verificationCode, err := newService.GeneratePhoneNumberVerificationCode(&user, phoneNumber)
 			if err != nil {
@@ -947,8 +954,9 @@ func VerifyPhoneNumberViaTelegramBotHandler(w http.ResponseWriter, r *http.Reque
 				},
 			})
 			if err != nil {
+				utils.HandleError(w, http.StatusInternalServerError, "failed to send message from the Telegram bot", err)
 				log.Printf("failed to send message from the Telegram bot: %v", err)
-				continue
+				return
 			}
 
 			zkProof, zkPairID, err := newService.GenerateZkProof(user, phoneNumber, verificationCode)

--- a/server/resource_server/service/service.go
+++ b/server/resource_server/service/service.go
@@ -405,7 +405,7 @@ func (s *service) RefreshTelegramMessages(baseURL string, offset int64) ([]dto.M
 	}
 
 	if !response.Ok {
-		return nil, fmt.Errorf("received not-ok response from the getUpdates endpoint of Telegram API")
+		return nil, fmt.Errorf("received not-ok response from the getUpdates endpoint of Telegram API, result: %v", response.Result)
 	}
 
 	return response.Result, nil


### PR DESCRIPTION
## Test Cases Checklist

### SECTION 1: RESOURCE SERVER (http://localhost:5001/)
- [ ] Created a new user on the Layer8 Portal

### SECTION 2: WE'VE GOT POEMS (http://localhost:5173/)
- [ ] Login as 'tester', '1234'
- [ ] Choose login with layer8 
- [ ] Logging in with the newly registered credentials from Section 1 succeeds in popup
- [ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [ ] Choose poems 1 - 3 works correctly 

### SECTION 3: IMSHARER (http://localhost:5174/)
- [ ] Uploads an image works
- [ ] Reload leads to instant reload (demonstrating proper caching)


